### PR TITLE
BinaryPropertyListParser improvement, reduced memory allocations

### DIFF
--- a/src/main/java/com/dd/plist/BinaryPropertyListParser.java
+++ b/src/main/java/com/dd/plist/BinaryPropertyListParser.java
@@ -40,16 +40,14 @@ public class BinaryPropertyListParser {
     /**
      * Major version of the property list format
      */
-    @SuppressWarnings("FieldCanBeLocal")
-    // Useful when the features of different format versions are implemented
-    private int    majorVersion;
+    @SuppressWarnings("FieldCanBeLocal") //Useful when the features of different format versions are implemented
+    private int majorVersion;
 
     /**
      * Minor version of the property list format
      */
-    @SuppressWarnings("FieldCanBeLocal")
-    // Useful when the features of different format versions are implemented
-    private int    minorVersion;
+    @SuppressWarnings("FieldCanBeLocal") //Useful when the features of different format versions are implemented
+    private int minorVersion;
 
     /**
      * property list in bytes
@@ -59,12 +57,12 @@ public class BinaryPropertyListParser {
     /**
      * Length of an object reference in bytes
      */
-    private int    objectRefSize;
+    private int objectRefSize;
 
     /**
      * The table holding the information at which offset each object is found
      */
-    private int[]  offsetTable;
+    private int[] offsetTable;
 
     /**
      * Protected constructor so that instantiation is fully controlled by the
@@ -182,78 +180,78 @@ public class BinaryPropertyListParser {
     private NSObject parseObject(int obj) throws PropertyListFormatException, UnsupportedEncodingException {
         int offset = offsetTable[obj];
         byte type = bytes[offset];
-        int objType = (type & 0xF0) >> 4; // First 4 bits
-        int objInfo = (type & 0x0F);      // Second 4 bits
+        int objType = (type & 0xF0) >> 4; //First  4 bits
+        int objInfo = (type & 0x0F);      //Second 4 bits
         switch (objType) {
             case 0x0: {
-                // Simple
+                //Simple
                 switch (objInfo) {
                     case 0x0: {
-                        // null object (v1.0 and later)
+                        //null object (v1.0 and later)
                         return null;
                     }
                     case 0x8: {
-                        // false
+                        //false
                         return new NSNumber(false);
                     }
                     case 0x9: {
-                        // true
+                        //true
                         return new NSNumber(true);
                     }
                     case 0xC: {
-                        // URL with no base URL (v1.0 and later)
-                        // TODO Implement binary URL parsing (not yet even implemented in Core Foundation as of revision 855.17)
+                        //URL with no base URL (v1.0 and later)
+                        //TODO Implement binary URL parsing (not yet even implemented in Core Foundation as of revision 855.17)
                         break;
                     }
                     case 0xD: {
-                        // URL with base URL (v1.0 and later)
-                        // TODO Implement binary URL parsing (not yet even implemented in Core Foundation as of revision 855.17)
+                        //URL with base URL (v1.0 and later)
+                        //TODO Implement binary URL parsing (not yet even implemented in Core Foundation as of revision 855.17)
                         break;
                     }
                     case 0xE: {
-                        // 16-byte UUID (v1.0 and later)
-                        // TODO Implement binary UUID parsing (not yet even implemented in Core Foundation as of revision 855.17)
+                        //16-byte UUID (v1.0 and later)
+                        //TODO Implement binary UUID parsing (not yet even implemented in Core Foundation as of revision 855.17)
                     }
                     case 0xF: {
-                        // filler byte
+                        //filler byte
                         return null;
                     }
                 }
                 break;
             }
             case 0x1: {
-                // integer
+                //integer
                 int length = (int) Math.pow(2, objInfo);
                 return new NSNumber(bytes, offset + 1, offset + 1 + length, NSNumber.INTEGER);
             }
             case 0x2: {
-                // real
+                //real
                 int length = (int) Math.pow(2, objInfo);
                 return new NSNumber(bytes, offset + 1, offset + 1 + length, NSNumber.REAL);
             }
             case 0x3: {
-                // Date
+                //Date
                 if (objInfo != 0x3) {
-                    throw new PropertyListFormatException("The given binary property list contains a date object of an unknown type (" + objInfo + ")");
+                    throw new PropertyListFormatException("The given binary property list contains a date object of an unknown type ("+objInfo+")");
                 }
                 return new NSDate(bytes, offset + 1, offset + 9);
             }
             case 0x4: {
-                // Data
+                //Data
                 int[] lengthAndOffset = readLengthAndOffset(objInfo, offset);
                 int length = lengthAndOffset[0];
                 int dataOffset = lengthAndOffset[1];
                 return new NSData(copyOfRange(bytes, offset + dataOffset, offset + dataOffset + length));
             }
             case 0x5: {
-                // ASCII string
+                //ASCII string
                 int[] lengthAndOffset = readLengthAndOffset(objInfo, offset);
-                int length = lengthAndOffset[0];  // Each character is 1 byte
+                int length = lengthAndOffset[0];  //Each character is 1 byte
                 int strOffset = lengthAndOffset[1];
                 return new NSString(bytes, offset + strOffset, offset + strOffset + length, "ASCII");
             }
             case 0x6: {
-                // UTF-16-BE string
+                //UTF-16-BE string
                 int[] lengthAndOffset = readLengthAndOffset(objInfo, offset);
                 int characters = lengthAndOffset[0];
                 int strOffset = lengthAndOffset[1];
@@ -273,12 +271,12 @@ public class BinaryPropertyListParser {
                 return new NSString(bytes, offset + strOffset, offset + strOffset + length, "UTF-8");
             }
             case 0x8: {
-                // UID (v1.0 and later)
+                //UID (v1.0 and later)
                 int length = objInfo + 1;
                 return new UID(String.valueOf(obj), copyOfRange(bytes, offset + 1, offset + 1 + length));
             }
             case 0xA: {
-                // Array
+                //Array
                 int[] lengthAndOffset = readLengthAndOffset(objInfo, offset);
                 int length = lengthAndOffset[0];
                 int arrayOffset = lengthAndOffset[1];
@@ -291,7 +289,7 @@ public class BinaryPropertyListParser {
                 return array;
             }
             case 0xB: {
-                // Ordered set (v1.0 and later)
+                //Ordered set (v1.0 and later)
                 int[] lengthAndOffset = readLengthAndOffset(objInfo, offset);
                 int length = lengthAndOffset[0];
                 int contentOffset = lengthAndOffset[1];
@@ -304,7 +302,7 @@ public class BinaryPropertyListParser {
                 return set;
             }
             case 0xC: {
-                // Set (v1.0 and later)
+                //Set (v1.0 and later)
                 int[] lengthAndOffset = readLengthAndOffset(objInfo, offset);
                 int length = lengthAndOffset[0];
                 int contentOffset = lengthAndOffset[1];
@@ -317,7 +315,7 @@ public class BinaryPropertyListParser {
                 return set;
             }
             case 0xD: {
-                // Dictionary
+                //Dictionary
                 int[] lengthAndOffset = readLengthAndOffset(objInfo, offset);
                 int length = lengthAndOffset[0];
                 int contentOffset = lengthAndOffset[1];
@@ -343,7 +341,7 @@ public class BinaryPropertyListParser {
      * Reads the length for arrays, sets and dictionaries.
      *
      * @param objInfo Object information byte.
-     * @param offset Offset in the byte array at which the object is located.
+     * @param offset  Offset in the byte array at which the object is located.
      * @return An array with the length two. First entry is the length, second entry the offset at which the content starts.
      */
     private int[] readLengthAndOffset(int objInfo, int offset) {
@@ -364,7 +362,7 @@ public class BinaryPropertyListParser {
                 lengthValue = new BigInteger(copyOfRange(bytes, offset + 2, offset + 2 + intLength)).intValue();
             }
         }
-        return new int[] { lengthValue, offsetValue };
+        return new int[]{lengthValue, offsetValue};
     }
 
     private int calculateUtf8StringLength(byte[] bytes, int offset, int numCharacters) {
@@ -411,6 +409,16 @@ public class BinaryPropertyListParser {
     }
 
     /**
+     * Parses an unsigned integers from a byte array.
+     *
+     * @param bytes The byte array containing the unsigned integer.
+     * @return The unsigned integer represented by the given bytes.
+     */
+    public static long parseUnsignedInt(byte[] bytes) {
+        return parseUnsignedInt(bytes, 0, bytes.length);
+    }
+
+    /**
      * Parses an unsigned integer from a byte array.
      *
      * @param bytes The byte array containing the unsigned integer.
@@ -426,6 +434,16 @@ public class BinaryPropertyListParser {
         }
         l &= 0xFFFFFFFFL;
         return l;
+    }
+
+    /**
+     * Parses a long from a (big-endian) byte array.
+     *
+     * @param bytes The bytes representing the long integer.
+     * @return The long integer represented by the given bytes.
+     */
+    public static long parseLong(byte[] bytes) {
+        return parseLong(bytes, 0, bytes.length);
     }
 
     /**
@@ -449,6 +467,16 @@ public class BinaryPropertyListParser {
      * Parses a double from a (big-endian) byte array.
      *
      * @param bytes The bytes representing the double.
+     * @return The double represented by the given bytes.
+     */
+    public static double parseDouble(byte[] bytes) {
+        return parseDouble(bytes, 0, bytes.length);
+    }
+
+    /**
+     * Parses a double from a (big-endian) byte array.
+     *
+     * @param bytes The bytes representing the double.
      * @param startIndex Beginning of the double in the byte array.
      * @param endIndex End of the double in the byte array.
      * @return The double represented by the given bytes.
@@ -457,21 +485,21 @@ public class BinaryPropertyListParser {
         if (endIndex - startIndex == 8) {
             return Double.longBitsToDouble(parseLong(bytes, startIndex, endIndex));
         } else if (endIndex - startIndex == 4) {
-            return Float.intBitsToFloat((int) parseLong(bytes, startIndex, endIndex));
+            return Float.intBitsToFloat((int)parseLong(bytes, startIndex, endIndex));
         } else {
-            throw new IllegalArgumentException("endIndex (" + endIndex + ") - startIndex (" + startIndex + ") != 4 or 8");
+            throw new IllegalArgumentException("endIndex ("+endIndex+") - startIndex ("+startIndex+") != 4 or 8");
         }
     }
 
     /**
      * Copies a part of a byte array into a new array.
      *
-     * @param src The source array.
+     * @param src        The source array.
      * @param startIndex The index from which to start copying.
-     * @param endIndex The index until which to copy.
+     * @param endIndex   The index until which to copy.
      * @return The copied array.
      */
-    private static byte[] copyOfRange(byte[] src, int startIndex, int endIndex) {
+    public static byte[] copyOfRange(byte[] src, int startIndex, int endIndex) {
         int length = endIndex - startIndex;
         if (length < 0) {
             throw new IllegalArgumentException("startIndex (" + startIndex + ")" + " > endIndex (" + endIndex + ")");

--- a/src/main/java/com/dd/plist/NSDate.java
+++ b/src/main/java/com/dd/plist/NSDate.java
@@ -94,11 +94,13 @@ public class NSDate extends NSObject {
     /**
      * Creates a date from its binary representation.
      *
-     * @param bytes The date bytes
+     * @param bytes byte array with all information
+     * @param startIndex int with the starting index of the date
+     * @param endIndex int with the end index of the date
      */
-    public NSDate(byte[] bytes) {
+    public NSDate(byte[] bytes, final int startIndex, final int endIndex) {
         //dates are 8 byte big-endian double, seconds since the epoch
-        date = new Date(EPOCH + (long) (1000 * BinaryPropertyListParser.parseDouble(bytes)));
+        date = new Date(EPOCH + (long) (1000 * BinaryPropertyListParser.parseDouble(bytes, startIndex, endIndex)));
     }
 
     /**

--- a/src/main/java/com/dd/plist/NSDate.java
+++ b/src/main/java/com/dd/plist/NSDate.java
@@ -94,6 +94,15 @@ public class NSDate extends NSObject {
     /**
      * Creates a date from its binary representation.
      *
+     * @param bytes The date bytes
+     */
+    public NSDate(byte[] bytes){
+        this(bytes, 0, bytes.length);
+    }
+
+    /**
+     * Creates a date from its binary representation.
+     *
      * @param bytes byte array with all information
      * @param startIndex int with the starting index of the date
      * @param endIndex int with the end index of the date

--- a/src/main/java/com/dd/plist/NSNumber.java
+++ b/src/main/java/com/dd/plist/NSNumber.java
@@ -62,19 +62,21 @@ public class NSNumber extends NSObject implements Comparable<Object> {
      * Parses integers and real numbers from their binary representation.
      * <i>Note: real numbers are not yet supported.</i>
      *
-     * @param bytes The binary representation
+     * @param bytes array of bytes with all the information inside
+     * @param startIndex int with the position where to start reading from the byte array
+     * @param endIndex int with the position where to end reading from the byte array
      * @param type  The type of number
      * @see #INTEGER
      * @see #REAL
      */
-    public NSNumber(byte[] bytes, int type) {
+    public NSNumber(byte[] bytes, final int startIndex, final int endIndex, final int type){
         switch (type) {
             case INTEGER: {
-                doubleValue = longValue = BinaryPropertyListParser.parseLong(bytes);
+                doubleValue = longValue = BinaryPropertyListParser.parseLong(bytes, startIndex, endIndex);
                 break;
             }
             case REAL: {
-                doubleValue = BinaryPropertyListParser.parseDouble(bytes);
+                doubleValue = BinaryPropertyListParser.parseDouble(bytes, startIndex, endIndex);
                 longValue = Math.round(doubleValue);
                 break;
             }

--- a/src/main/java/com/dd/plist/NSNumber.java
+++ b/src/main/java/com/dd/plist/NSNumber.java
@@ -62,7 +62,20 @@ public class NSNumber extends NSObject implements Comparable<Object> {
      * Parses integers and real numbers from their binary representation.
      * <i>Note: real numbers are not yet supported.</i>
      *
-     * @param bytes array of bytes with all the information inside
+     * @param bytes The binary representation of only this number
+     * @param type  The type of number
+     * @see #INTEGER
+     * @see #REAL
+     */
+    public NSNumber(byte[] bytes, int type){
+        this(bytes, 0, bytes.length, type);
+    }
+
+    /**
+     * Parses integers and real numbers from their binary representation.
+     * <i>Note: real numbers are not yet supported.</i>
+     *
+     * @param bytes array of bytes that contains this number's binary representation
      * @param startIndex int with the position where to start reading from the byte array
      * @param endIndex int with the position where to end reading from the byte array
      * @param type  The type of number

--- a/src/main/java/com/dd/plist/NSString.java
+++ b/src/main/java/com/dd/plist/NSString.java
@@ -41,10 +41,23 @@ public class NSString extends NSObject implements Comparable<Object> {
     /**
      * Creates an NSString from its binary representation.
      *
+     * @param bytes    The binary representation.
+     * @param encoding The encoding of the binary representation, the name of a supported charset.
+     * @throws UnsupportedEncodingException When the given encoding is not supported by the JRE.
+     * @see java.lang.String#String(byte[], String)
+     */
+    public NSString(byte[] bytes, String encoding) throws UnsupportedEncodingException {
+        this(bytes, 0, bytes.length, encoding);
+    }
+
+    /**
+     * Creates an NSString from its binary representation.
+     *
      * @param bytes The binary representation.
      * @param startIndex int with the index where to start (offset)
      * @param endIndex int with the index where to stop reading (offset + string length)
-     * @param encoding The encoding of the binary representation, the name of a supported charset. @throws UnsupportedEncodingException When the given encoding is not supported by the JRE.
+     * @param encoding The encoding of the binary representation, the name of a supported charset.
+     * @throws UnsupportedEncodingException When the given encoding is not supported by the JRE.
      * @see java.lang.String#String(byte[], String)
      */
     public NSString(byte[] bytes, final int startIndex, final int endIndex, String encoding) throws UnsupportedEncodingException {
@@ -142,7 +155,7 @@ public class NSString extends NSObject implements Comparable<Object> {
         indent(xml, level);
         xml.append("<string>");
 
-        // Make sure that the string is encoded in UTF-8 for the XML output
+        //Make sure that the string is encoded in UTF-8 for the XML output
         synchronized (NSString.class) {
             if (utf8Encoder == null)
                 utf8Encoder = Charset.forName("UTF-8").newEncoder();
@@ -159,8 +172,8 @@ public class NSString extends NSObject implements Comparable<Object> {
             }
         }
 
-        // According to http://www.w3.org/TR/REC-xml/#syntax node values must not
-        // contain the characters < or &. Also the > character should be escaped.
+        //According to http://www.w3.org/TR/REC-xml/#syntax node values must not
+        //contain the characters < or &. Also the > character should be escaped.
         if (content.contains("&") || content.contains("<") || content.contains(">")) {
             xml.append("<![CDATA[");
             xml.append(content.replaceAll("]]>", "]]]]><![CDATA[>"));
@@ -170,6 +183,7 @@ public class NSString extends NSObject implements Comparable<Object> {
         }
         xml.append("</string>");
     }
+
 
     @Override
     public void toBinary(BinaryPropertyListWriter out) throws IOException {
@@ -205,10 +219,10 @@ public class NSString extends NSObject implements Comparable<Object> {
     protected void toASCII(StringBuilder ascii, int level) {
         indent(ascii, level);
         ascii.append("\"");
-        // According to https://developer.apple.com/library/mac/#documentation/Cocoa/Conceptual/PropertyLists/OldStylePlists/OldStylePLists.html
-        // non-ASCII characters are not escaped but simply written into the
-        // file, thus actually violating the ASCII plain text format.
-        // We will escape the string anyway because current Xcode project files (ASCII property lists) also escape their strings.
+        //According to https://developer.apple.com/library/mac/#documentation/Cocoa/Conceptual/PropertyLists/OldStylePlists/OldStylePLists.html
+        //non-ASCII characters are not escaped but simply written into the
+        //file, thus actually violating the ASCII plain text format.
+        //We will escape the string anyway because current Xcode project files (ASCII property lists) also escape their strings.
         ascii.append(escapeStringForASCII(content));
         ascii.append("\"");
     }
@@ -233,7 +247,7 @@ public class NSString extends NSObject implements Comparable<Object> {
         for (int i = 0; i < cArray.length; i++) {
             char c = cArray[i];
             if (c > 127) {
-                // non-ASCII Unicode
+                //non-ASCII Unicode
                 out += "\\U";
                 String hex = Integer.toHexString(c);
                 while (hex.length() < 4)


### PR DESCRIPTION
Removed most references to copyOfRange inside BinaryPropertyListParser, instead, most NS-Clases now accept the complete byte array and the range that they should copy.

By using this approach, the amount of Byte arrays reserved in memory take about 50-80% less, with a general speed increase of 20-50% depending on the memory stress and the platform used.

*Memory*
![memory](https://cloud.githubusercontent.com/assets/1800418/6927528/52c191ee-d7ee-11e4-8724-0d4ee05ce36b.png)

*Time*
![speed](https://cloud.githubusercontent.com/assets/1800418/6927537/603d5830-d7ee-11e4-97e3-965ac57a938e.png)

Please note the following:
 1. these are just average test results with an over 5MB binary plist parsed that includes NSString, NSNumber, NSArray, NSDictionary and NSDate.
 2. the results include other small adjustments on NSString and NSNumber pending for a pull request. This is my first pull request ever and I mistakenly made all changes to my own master branch, I will continue splitting the changes to individually pull request. Feel free to check some changes to come in my forked master branch.