### PR TITLE
squid:S1157, squid:S2162 - Case insensitive string comparisons should…

### DIFF
--- a/src/main/java/com/dd/plist/NSNumber.java
+++ b/src/main/java/com/dd/plist/NSNumber.java
@@ -123,8 +123,8 @@ public class NSNumber extends NSObject implements Comparable<Object> {
                 type = REAL;
             } catch (Exception ex2) {
                 try {
-                    boolValue = text.toLowerCase().equals("true") || text.toLowerCase().equals("yes");
-                    if(!boolValue && !(text.toLowerCase().equals("false") || text.toLowerCase().equals("no"))) {
+                    boolValue = text.equalsIgnoreCase("true") || text.equalsIgnoreCase("yes");
+                    if(!boolValue && !(text.equalsIgnoreCase("false") || text.equalsIgnoreCase("no"))) {
                         throw new Exception("not a boolean");
                     }
                     type = BOOLEAN;
@@ -276,7 +276,8 @@ public class NSNumber extends NSObject implements Comparable<Object> {
      */
     @Override
     public boolean equals(Object obj) {
-        if (!(obj instanceof NSNumber)) return false;
+        if (obj == null) return false;
+        if (this.getClass() != obj.getClass()) return false;
         NSNumber n = (NSNumber) obj;
         return type == n.type && longValue == n.longValue && doubleValue == n.doubleValue && boolValue == n.boolValue;
     }

--- a/src/main/java/com/dd/plist/NSString.java
+++ b/src/main/java/com/dd/plist/NSString.java
@@ -129,7 +129,8 @@ public class NSString extends NSObject implements Comparable<Object> {
 
     @Override
     public boolean equals(Object obj) {
-        if (!(obj instanceof NSString)) return false;
+        if (obj == null) return false;
+        if (this.getClass() != obj.getClass()) return false;
         return content.equals(((NSString) obj).content);
     }
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules squid:S1157 - Case insensitive string comparisons should be made without intermediate upper or lower casing
squid:S2162 - "equals" methods should be symmetric and work for subclasses

You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid:S1157
https://dev.eclipse.org/sonar/coding_rules#q=squid:S2162

Please let me know if you have any questions.

M-Ezzat