### PR TITLE
Use LinkedHashMap instead of HashMap so order is defined across Java versions

### DIFF
--- a/src/main/java/com/dd/plist/BinaryPropertyListWriter.java
+++ b/src/main/java/com/dd/plist/BinaryPropertyListWriter.java
@@ -29,7 +29,7 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 /**
@@ -143,7 +143,7 @@ public class BinaryPropertyListWriter {
     private long count;
 
     // map from object to its ID
-    private Map<NSObject, Integer> idMap = new HashMap<NSObject, Integer>();
+    private Map<NSObject, Integer> idMap = new LinkedHashMap<NSObject, Integer>();
     private int idSizeInBytes;
 
     /**


### PR DESCRIPTION
`HashMap` has an undefined ordering; switch to `LinkedHashMap` to guarantee insertion order.

Before this, this was causing Java 7 and Java 8 to generate different binary output for the same input.