### PR TITLE
squid:UselessParenthesesCheck - Useless parentheses around expression…

### DIFF
--- a/src/main/java/com/dd/plist/Base64.java
+++ b/src/main/java/com/dd/plist/Base64.java
@@ -562,21 +562,21 @@ public class Base64 {
 
         switch (numSigBytes) {
             case 3:
-                destination[destOffset] = ALPHABET[(inBuff >>> 18)];
+                destination[destOffset] = ALPHABET[inBuff >>> 18];
                 destination[destOffset + 1] = ALPHABET[(inBuff >>> 12) & 0x3f];
                 destination[destOffset + 2] = ALPHABET[(inBuff >>> 6) & 0x3f];
                 destination[destOffset + 3] = ALPHABET[(inBuff) & 0x3f];
                 return destination;
 
             case 2:
-                destination[destOffset] = ALPHABET[(inBuff >>> 18)];
+                destination[destOffset] = ALPHABET[inBuff >>> 18];
                 destination[destOffset + 1] = ALPHABET[(inBuff >>> 12) & 0x3f];
                 destination[destOffset + 2] = ALPHABET[(inBuff >>> 6) & 0x3f];
                 destination[destOffset + 3] = EQUALS_SIGN;
                 return destination;
 
             case 1:
-                destination[destOffset] = ALPHABET[(inBuff >>> 18)];
+                destination[destOffset] = ALPHABET[inBuff >>> 18];
                 destination[destOffset + 1] = ALPHABET[(inBuff >>> 12) & 0x3f];
                 destination[destOffset + 2] = EQUALS_SIGN;
                 destination[destOffset + 3] = EQUALS_SIGN;
@@ -1137,7 +1137,7 @@ public class Base64 {
             int outBuff = ((DECODABET[source[srcOffset]] & 0xFF) << 18)
                     | ((DECODABET[source[srcOffset + 1]] & 0xFF) << 12)
                     | ((DECODABET[source[srcOffset + 2]] & 0xFF) << 6)
-                    | ((DECODABET[source[srcOffset + 3]] & 0xFF));
+                    | (DECODABET[source[srcOffset + 3]] & 0xFF);
 
 
             destination[destOffset] = (byte) (outBuff >> 16);

--- a/src/main/java/com/dd/plist/BinaryPropertyListParser.java
+++ b/src/main/java/com/dd/plist/BinaryPropertyListParser.java
@@ -181,7 +181,7 @@ public class BinaryPropertyListParser {
         int offset = offsetTable[obj];
         byte type = bytes[offset];
         int objType = (type & 0xF0) >> 4; //First  4 bits
-        int objInfo = (type & 0x0F);      //Second 4 bits
+        int objInfo = type & 0x0F;      //Second 4 bits
         switch (objType) {
             case 0x0: {
                 //Simple

--- a/src/main/java/com/dd/plist/BinaryPropertyListWriter.java
+++ b/src/main/java/com/dd/plist/BinaryPropertyListWriter.java
@@ -111,7 +111,7 @@ public class BinaryPropertyListWriter {
     public static void write(OutputStream out, NSObject root) throws IOException {
         int minVersion = getMinimumRequiredVersion(root);
         if (minVersion > VERSION_00) {
-            String versionString = ((minVersion == VERSION_10) ? "v1.0" : ((minVersion == VERSION_15) ? "v1.5" : ((minVersion == VERSION_20) ? "v2.0" : "v0.0")));
+            String versionString = minVersion == VERSION_10 ? "v1.0" : (minVersion == VERSION_15 ? "v1.5" : (minVersion == VERSION_20 ? "v2.0" : "v0.0"));
             throw new IOException("The given property list structure cannot be saved. " +
                     "The required version of the binary format (" + versionString + ") is not yet supported.");
         }

--- a/src/main/java/com/dd/plist/NSDictionary.java
+++ b/src/main/java/com/dd/plist/NSDictionary.java
@@ -355,7 +355,7 @@ public class NSDictionary extends NSObject  implements Map<String, NSObject> {
 
     @Override
     public boolean equals(Object obj) {
-        return (obj.getClass().equals(this.getClass()) && ((NSDictionary) obj).dict.equals(dict));
+        return obj.getClass().equals(this.getClass()) && ((NSDictionary) obj).dict.equals(dict);
     }
 
     /**

--- a/src/main/java/com/dd/plist/NSString.java
+++ b/src/main/java/com/dd/plist/NSString.java
@@ -277,7 +277,7 @@ public class NSString extends NSObject implements Comparable<Object> {
         if (o instanceof NSString) {
             return getContent().compareTo(((NSString) o).getContent());
         } else if (o instanceof String) {
-            return getContent().compareTo(((String) o));
+            return getContent().compareTo((String) o);
         } else {
             return -1;
         }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:UselessParenthesesCheck - Useless parentheses around expressions should be removed to prevent any misunderstanding

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:UselessParenthesesCheck

Please let me know if you have any questions.

M-Ezzat