### PR TITLE
squid:S1213 - The members of an interface declaration or class should…

### DIFF
--- a/src/main/java/com/dd/plist/ASCIIPropertyListParser.java
+++ b/src/main/java/com/dd/plist/ASCIIPropertyListParser.java
@@ -57,44 +57,6 @@ import java.util.List;
  */
 public class ASCIIPropertyListParser {
 
-    /**
-     * Parses an ASCII property list file.
-     *
-     * @param f The ASCII property list file.
-     * @return The root object of the property list. This is usually a NSDictionary but can also be a NSArray.
-     * @throws java.text.ParseException When an error occurs during parsing.
-     * @throws java.io.IOException When an error occured while reading from the input stream.
-     */
-    public static NSObject parse(File f) throws IOException, ParseException {
-        return parse(new FileInputStream(f));
-    }
-
-    /**
-     * Parses an ASCII property list from an input stream.
-     *
-     * @param in The input stream that points to the property list's data.
-     * @return The root object of the property list. This is usually a NSDictionary but can also be a NSArray.
-     * @throws java.text.ParseException When an error occurs during parsing.
-     * @throws java.io.IOException When an error occured while reading from the input stream.
-     */
-    public static NSObject parse(InputStream in) throws ParseException, IOException {
-        byte[] buf = PropertyListParser.readAll(in);
-        in.close();
-        return parse(buf);
-    }
-
-    /**
-     * Parses an ASCII property list from a byte array.
-     *
-     * @param bytes The ASCII property list data.
-     * @return The root object of the property list. This is usually a NSDictionary but can also be a NSArray.
-     * @throws ParseException When an error occurs during parsing.
-     */
-    public static NSObject parse(byte[] bytes) throws ParseException {
-        ASCIIPropertyListParser parser = new ASCIIPropertyListParser(bytes);
-        return parser.parse();
-    }
-
     public static final char WHITESPACE_SPACE = ' ';
     public static final char WHITESPACE_TAB = '\t';
     public static final char WHITESPACE_NEWLINE = '\n';
@@ -136,6 +98,11 @@ public class ASCIIPropertyListParser {
     public static final char MULTILINE_COMMENT_END_TOKEN = '/';
 
     /**
+     * Used to encode the parsed strings
+     */
+    private static CharsetEncoder asciiEncoder;
+
+    /**
      * Property list source data
      */
     private byte[] data;
@@ -158,6 +125,44 @@ public class ASCIIPropertyListParser {
      */
     private ASCIIPropertyListParser(byte[] propertyListContent) {
         data = propertyListContent;
+    }
+
+    /**
+     * Parses an ASCII property list file.
+     *
+     * @param f The ASCII property list file.
+     * @return The root object of the property list. This is usually a NSDictionary but can also be a NSArray.
+     * @throws java.text.ParseException When an error occurs during parsing.
+     * @throws java.io.IOException When an error occured while reading from the input stream.
+     */
+    public static NSObject parse(File f) throws IOException, ParseException {
+        return parse(new FileInputStream(f));
+    }
+
+    /**
+     * Parses an ASCII property list from an input stream.
+     *
+     * @param in The input stream that points to the property list's data.
+     * @return The root object of the property list. This is usually a NSDictionary but can also be a NSArray.
+     * @throws java.text.ParseException When an error occurs during parsing.
+     * @throws java.io.IOException When an error occured while reading from the input stream.
+     */
+    public static NSObject parse(InputStream in) throws ParseException, IOException {
+        byte[] buf = PropertyListParser.readAll(in);
+        in.close();
+        return parse(buf);
+    }
+
+    /**
+     * Parses an ASCII property list from a byte array.
+     *
+     * @param bytes The ASCII property list data.
+     * @return The root object of the property list. This is usually a NSDictionary but can also be a NSArray.
+     * @throws ParseException When an error occurs during parsing.
+     */
+    public static NSObject parse(byte[] bytes) throws ParseException {
+        ASCIIPropertyListParser parser = new ASCIIPropertyListParser(bytes);
+        return parser.parse();
     }
 
     /**
@@ -566,11 +571,6 @@ public class ASCIIPropertyListParser {
         skip();
         return unescapedString;
     }
-
-    /**
-     * Used to encode the parsed strings
-     */
-    private static CharsetEncoder asciiEncoder;
 
     /**
      * Parses a string according to the format specified for ASCII property lists.

--- a/src/main/java/com/dd/plist/Base64.java
+++ b/src/main/java/com/dd/plist/Base64.java
@@ -257,6 +257,12 @@ public class Base64 {
     private final static byte WHITE_SPACE_ENC = -5; // Indicates white space in encoding
     private final static byte EQUALS_SIGN_ENC = -1; // Indicates equals sign in encoding
 
+    /**
+     * Defeats instantiation.
+     */
+    private Base64() {
+    }
+
 
 /* ********  S T A N D A R D   B A S E 6 4   A L P H A B E T  ******** */
 
@@ -481,15 +487,6 @@ public class Base64 {
             return _STANDARD_DECODABET;
         }
     }    // end getAlphabet
-
-
-    /**
-     * Defeats instantiation.
-     */
-    private Base64() {
-    }
-
-
 
 
 /* ********  E N C O D I N G   M E T H O D S  ******** */

--- a/src/main/java/com/dd/plist/BinaryPropertyListWriter.java
+++ b/src/main/java/com/dd/plist/BinaryPropertyListWriter.java
@@ -47,6 +47,34 @@ public class BinaryPropertyListWriter {
     public static final int VERSION_15 = 15;
     public static final int VERSION_20 = 20;
 
+    private int version = VERSION_00;
+
+    // raw output stream to result file
+    private OutputStream out;
+
+    // # of bytes written so far
+    private long count;
+
+    // map from object to its ID
+    private Map<NSObject, Integer> idMap = new LinkedHashMap<NSObject, Integer>();
+    private int idSizeInBytes;
+
+    /**
+     * Creates a new binary property list writer
+     *
+     * @param outStr The output stream into which the binary property list will be written
+     * @throws IOException When an IO error occurs while writing to the stream or the object structure contains
+     *                     data that cannot be saved.
+     */
+    BinaryPropertyListWriter(OutputStream outStr) throws IOException {
+        out = new BufferedOutputStream(outStr);
+    }
+
+    BinaryPropertyListWriter(OutputStream outStr, int version) throws IOException {
+        this.version = version;
+        out = new BufferedOutputStream(outStr);
+    }
+
     /**
      * Finds out the minimum binary property list format version that
      * can be used to save the given NSObject tree.
@@ -132,34 +160,6 @@ public class BinaryPropertyListWriter {
         ByteArrayOutputStream bout = new ByteArrayOutputStream();
         write(bout, root);
         return bout.toByteArray();
-    }
-
-    private int version = VERSION_00;
-
-    // raw output stream to result file
-    private OutputStream out;
-
-    // # of bytes written so far
-    private long count;
-
-    // map from object to its ID
-    private Map<NSObject, Integer> idMap = new LinkedHashMap<NSObject, Integer>();
-    private int idSizeInBytes;
-
-    /**
-     * Creates a new binary property list writer
-     *
-     * @param outStr The output stream into which the binary property list will be written
-     * @throws IOException When an IO error occurs while writing to the stream or the object structure contains
-     *                     data that cannot be saved.
-     */
-    BinaryPropertyListWriter(OutputStream outStr) throws IOException {
-        out = new BufferedOutputStream(outStr);
-    }
-
-    BinaryPropertyListWriter(OutputStream outStr, int version) throws IOException {
-        this.version = version;
-        out = new BufferedOutputStream(outStr);
     }
 
     void write(NSObject root) throws IOException {

--- a/src/main/java/com/dd/plist/NSDate.java
+++ b/src/main/java/com/dd/plist/NSDate.java
@@ -46,6 +46,49 @@ public class NSDate extends NSObject {
     private static final SimpleDateFormat sdfDefault = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
     private static final SimpleDateFormat sdfGnuStep = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss Z");
 
+    /**
+     * Creates a date from its binary representation.
+     *
+     * @param bytes The date bytes
+     */
+    public NSDate(byte[] bytes){
+        this(bytes, 0, bytes.length);
+    }
+
+    /**
+     * Creates a date from its binary representation.
+     *
+     * @param bytes byte array with all information
+     * @param startIndex int with the starting index of the date
+     * @param endIndex int with the end index of the date
+     */
+    public NSDate(byte[] bytes, final int startIndex, final int endIndex) {
+        //dates are 8 byte big-endian double, seconds since the epoch
+        date = new Date(EPOCH + (long) (1000 * BinaryPropertyListParser.parseDouble(bytes, startIndex, endIndex)));
+    }
+
+    /**
+     * Parses a date from its textual representation.
+     * That representation has the following pattern: <code>yyyy-MM-dd'T'HH:mm:ss'Z'</code>
+     *
+     * @param textRepresentation The textual representation of the date (ISO 8601 format)
+     * @throws ParseException When the date could not be parsed, i.e. it does not match the expected pattern.
+     */
+    public NSDate(String textRepresentation) throws ParseException {
+        date = parseDateString(textRepresentation);
+    }
+
+    /**
+     * Creates a NSDate from a Java Date
+     *
+     * @param d The date
+     */
+    public NSDate(Date d) {
+        if (d == null)
+            throw new IllegalArgumentException("Date cannot be null");
+        date = d;
+    }
+
     static {
         sdfDefault.setTimeZone(TimeZone.getTimeZone("GMT"));
         sdfGnuStep.setTimeZone(TimeZone.getTimeZone("GMT"));
@@ -89,49 +132,6 @@ public class NSDate extends NSObject {
      */
     private static synchronized String makeDateStringGnuStep(Date date) {
         return sdfGnuStep.format(date);
-    }
-
-    /**
-     * Creates a date from its binary representation.
-     *
-     * @param bytes The date bytes
-     */
-    public NSDate(byte[] bytes){
-        this(bytes, 0, bytes.length);
-    }
-
-    /**
-     * Creates a date from its binary representation.
-     *
-     * @param bytes byte array with all information
-     * @param startIndex int with the starting index of the date
-     * @param endIndex int with the end index of the date
-     */
-    public NSDate(byte[] bytes, final int startIndex, final int endIndex) {
-        //dates are 8 byte big-endian double, seconds since the epoch
-        date = new Date(EPOCH + (long) (1000 * BinaryPropertyListParser.parseDouble(bytes, startIndex, endIndex)));
-    }
-
-    /**
-     * Parses a date from its textual representation.
-     * That representation has the following pattern: <code>yyyy-MM-dd'T'HH:mm:ss'Z'</code>
-     *
-     * @param textRepresentation The textual representation of the date (ISO 8601 format)
-     * @throws ParseException When the date could not be parsed, i.e. it does not match the expected pattern.
-     */
-    public NSDate(String textRepresentation) throws ParseException {
-        date = parseDateString(textRepresentation);
-    }
-
-    /**
-     * Creates a NSDate from a Java Date
-     *
-     * @param d The date
-     */
-    public NSDate(Date d) {
-        if (d == null)
-            throw new IllegalArgumentException("Date cannot be null");
-        date = d;
     }
 
     /**

--- a/src/main/java/com/dd/plist/NSString.java
+++ b/src/main/java/com/dd/plist/NSString.java
@@ -38,6 +38,8 @@ public class NSString extends NSObject implements Comparable<Object> {
 
     private String content;
 
+    private static CharsetEncoder asciiEncoder, utf16beEncoder, utf8Encoder;
+
     /**
      * Creates an NSString from its binary representation.
      *
@@ -148,8 +150,6 @@ public class NSString extends NSObject implements Comparable<Object> {
     public String toString() {
         return content;
     }
-
-    private static CharsetEncoder asciiEncoder, utf16beEncoder, utf8Encoder;
 
     @Override
     void toXML(StringBuilder xml, int level) {

--- a/src/main/java/com/dd/plist/XMLPropertyListParser.java
+++ b/src/main/java/com/dd/plist/XMLPropertyListParser.java
@@ -45,14 +45,14 @@ import java.util.List;
  */
 public class XMLPropertyListParser {
 
+    private static DocumentBuilderFactory docBuilderFactory = null;
+
     /**
      * Instantiation is prohibited by outside classes.
      */
     protected XMLPropertyListParser() {
         /** empty **/
     }
-
-    private static DocumentBuilderFactory docBuilderFactory = null;
 
     /**
      * Initialize the document builder factory so that it can be reused and does not need to


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S1213

Please let me know if you have any questions.

M-Ezzat