### PR TITLE
Properly parse unescaped UTF8 characters in quoted strings

### DIFF
--- a/src/test/java/com/dd/plist/test/ParseTest.java
+++ b/src/test/java/com/dd/plist/test/ParseTest.java
@@ -156,4 +156,12 @@ public class ParseTest extends TestCase {
 		// parsing the 200ko file should take way less than 5s 
 		executor.submit(task).get(5, TimeUnit.SECONDS);
     }
+
+    public static void testAsciiUtf8CharactersInQuotedString() throws Exception {
+        NSObject x = PropertyListParser.parse(new File("test-files/test-ascii-utf8.plist"));
+        NSDictionary d = (NSDictionary)x;
+        assertEquals(2, d.count());
+        assertEquals("JÔÖú@2x.jpg", d.objectForKey("path").toString());
+        assertEquals("QÔÖú@2x 啕.jpg", d.objectForKey("Key QÔÖª@2x 䌡").toString());
+    }
 }

--- a/test-files/test-ascii-utf8.plist
+++ b/test-files/test-ascii-utf8.plist
@@ -1,0 +1,5 @@
+// !$*UTF8*$!
+{
+    path = "JÔÖú@2x.jpg";
+    "Key QÔÖª@2x \u4321" = "QÔÖú@2x 啕.jpg";
+} 


### PR DESCRIPTION
If a quoted string contained unescaped UTF-8 characters (e.g. JÔÖú@2x.jpg), they were converted into ASCII.

I didn't change the way non-quoted strings are parsed, as it seems keys are always ASCII.
I removed the conversion to ASCII via the ASCII encoder, because it didn't work anymore.

