### PR TITLE
Support base-16 integer values in XML plists

### DIFF
--- a/src/main/java/com/dd/plist/NSNumber.java
+++ b/src/main/java/com/dd/plist/NSNumber.java
@@ -113,7 +113,12 @@ public class NSNumber extends NSObject implements Comparable<Object> {
         if (text == null)
             throw new IllegalArgumentException("The given string is null and cannot be parsed as number.");
         try {
-            long l = Long.parseLong(text);
+            long l;
+            if (text.startsWith("0x")) {
+                l  = Long.parseLong(text.substring(2), 16);
+            } else {
+                l  = Long.parseLong(text);
+            }
             doubleValue = longValue = l;
             type = INTEGER;
         } catch (Exception ex) {


### PR DESCRIPTION
The file /System/Library/Frameworks/Carbon.framework/Versions/Current/Frameworks/OpenScripting.framework/Resources/Info.plist (on my laptop) contains:

```
<integer>0x00000001</integer>
```

... so we need to be able to parse that!