### PR TITLE
Added support for empty plist files

### DIFF
--- a/src/main/java/com/dd/plist/NSNumber.java
+++ b/src/main/java/com/dd/plist/NSNumber.java
@@ -113,7 +113,12 @@ public class NSNumber extends NSObject implements Comparable<Object> {
         if (text == null)
             throw new IllegalArgumentException("The given string is null and cannot be parsed as number.");
         try {
-            long l = Long.parseLong(text);
+            long l;
+            if (text.startsWith("0x")) {
+                l  = Long.parseLong(text.substring(2), 16);
+            } else {
+                l  = Long.parseLong(text);
+            }
             doubleValue = longValue = l;
             type = INTEGER;
         } catch (Exception ex) {


### PR DESCRIPTION
PropertyListParser.parse will return a null for empty files, instead of throwing an ArrayIndexOutOfBoundsException.

In implementing this, I noticed duplication of code blocks between some of the parse methods, so I made parse(InputStream) the primary method.  In doing so, I also fixed the determineType mark/reset logic, so that arbitrary quantities of white-space can be skipped.

Finally, I fixed the logic for end-of-stream detection in the InputStream and byte array determineType methods (i.e., false && true || true == true vs. false && (true || true)) == false).