### PR TITLE
ensure that the first letter of a NSObject entry key is lower case

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -38,9 +38,6 @@
       <property name="caretWidth" class="java.lang.Integer" />
     </properties>
   </component>
-  <component name="EntryPointsManager">
-    <entry_points version="2.0" />
-  </component>
   <component name="MavenProjectsManager">
     <option name="originalFiles">
       <list>
@@ -48,17 +45,7 @@
       </list>
     </option>
   </component>
-  <component name="ProjectLevelVcsManager" settingsEditedManually="false">
-    <OptionsSetting value="true" id="Add" />
-    <OptionsSetting value="true" id="Remove" />
-    <OptionsSetting value="true" id="Checkout" />
-    <OptionsSetting value="true" id="Update" />
-    <OptionsSetting value="true" id="Status" />
-    <OptionsSetting value="true" id="Edit" />
-    <ConfirmationsSetting value="0" id="Add" />
-    <ConfirmationsSetting value="0" id="Remove" />
-  </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_6" default="false" assert-keyword="true" jdk-15="true" project-jdk-name="1.8" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_6" default="false" project-jdk-name="1.8 jdk" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/classes" />
   </component>
 </project>

--- a/src/main/java/com/dd/plist/NSObject.java
+++ b/src/main/java/com/dd/plist/NSObject.java
@@ -328,8 +328,12 @@ public abstract class NSObject {
         }
 
         for (Map.Entry<String, NSObject> entry : map.entrySet()) {
-            Method setter = setters.get(entry.getKey());
-            Method getter = getters.get(entry.getKey());
+            String key = entry.getKey();
+            char c[] = key.toCharArray();
+            c[0] = Character.toLowerCase(c[0]);
+            key = new String(c);
+            Method setter = setters.get(key);
+            Method getter = getters.get(key);
             if (setter != null && getter != null) {
 
                 Class<?> elemClass = getter.getReturnType();


### PR DESCRIPTION
if a plist <key> - value is capitalized the Map key of the NSDirectory - entry is also capitalize
but the keys of the getter and setter maps determined by reflection, are not capitalized
so to match the getter and setter keys, the entry key has to start with a lower case character