### PR TITLE
ASCIIPropertyList.java: properly parse escaped special characters

### DIFF
--- a/src/main/java/com/dd/plist/ASCIIPropertyListParser.java
+++ b/src/main/java/com/dd/plist/ASCIIPropertyListParser.java
@@ -633,11 +633,15 @@ public final class ASCIIPropertyListParser {
         {
             case '\\':
             case '"':
-            case 'b':
-            case 'n':
-            case 'r':
-            case 't':
                 return c;
+            case 'b':
+                return '\b';
+            case 'n':
+                return '\n';
+            case 'r':
+                return '\r';
+            case 't':
+                return '\t';
 
             case 'U':
             case 'u':

--- a/src/test/java/com/dd/plist/test/DeSerializationTest.java
+++ b/src/test/java/com/dd/plist/test/DeSerializationTest.java
@@ -328,4 +328,19 @@ public class DeSerializationTest extends TestCase {
         assertEquals("In reinen Text umwandeln", dict.get("Make Plain Text").toString());
     }
 
+    public void testParseSpecialCharacters() throws Exception {
+        String asciiPropertyList = "{\n" +
+                "a = \"abc \\n def\";\n" +
+                "b = \"\\r\";\n" +
+                "c = \"xyz\\b\";\n" +
+                "d = \"\\tasdf\";\n" +
+                "e = \"\\\\ \\\"\";\n" +
+                "}";
+        NSDictionary dict = (NSDictionary)ASCIIPropertyListParser.parse(asciiPropertyList.getBytes(Charset.forName("UTF-8")));
+        assertEquals("abc \n def", dict.get("a").toString());
+        assertEquals("\r", dict.get("b").toString());
+        assertEquals("xyz\b", dict.get("c").toString());
+        assertEquals("\tasdf", dict.get("d").toString());
+        assertEquals("\\ \"", dict.get("e").toString());
+    }
 }


### PR DESCRIPTION
e.g. parse "\n" to a newline, rather than "n"