### PR TITLE
ASCIIPropertyListParser: handle non-7b-ASCII chars

### DIFF
--- a/src/main/java/com/dd/plist/ASCIIPropertyListParser.java
+++ b/src/main/java/com/dd/plist/ASCIIPropertyListParser.java
@@ -22,6 +22,7 @@
  */
 package com.dd.plist;
 
+import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -299,6 +300,14 @@ public final class ASCIIPropertyListParser {
         while (commentSkipped); //if a comment was skipped more whitespace or another comment can follow, so skip again
     }
 
+    private String toUtf8String(ByteArrayOutputStream stream) {
+        try {
+            return stream.toString("UTF-8");
+        } catch (UnsupportedEncodingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
     /**
      * Reads input until one of the given symbols is found.
      *
@@ -306,13 +315,12 @@ public final class ASCIIPropertyListParser {
      * @return The input until one the given symbols.
      */
     private String readInputUntil(char... symbols) {
-        StringBuilder strBuf = new StringBuilder();
-        while (!this.accept(symbols)) {
-        	  strBuf.append((char) this.data[this.index]);
-            this.skip();
+        ByteArrayOutputStream stringBytes = new ByteArrayOutputStream();
+        while (!accept(symbols)) {
+            stringBytes.write(data[index]);
+            skip();
         }
-
-        return strBuf.toString();
+        return toUtf8String(stringBytes);
     }
 
     /**
@@ -322,12 +330,12 @@ public final class ASCIIPropertyListParser {
      * @return The input until the given symbol.
      */
     private String readInputUntil(char symbol) {
-        StringBuilder strBuf = new StringBuilder();
-        while (!this.accept(symbol)) {
-        	  strBuf.append((char) this.data[this.index]);
-            this.skip();
+        ByteArrayOutputStream stringBytes = new ByteArrayOutputStream();
+        while (!accept(symbol)) {
+            stringBytes.write(data[index]);
+            skip();
         }
-        return strBuf.toString();
+        return toUtf8String(stringBytes);
     }
 
     /**

--- a/src/test/java/com/dd/plist/test/DeSerializationTest.java
+++ b/src/test/java/com/dd/plist/test/DeSerializationTest.java
@@ -343,4 +343,19 @@ public class DeSerializationTest extends TestCase {
         assertEquals("\tasdf", dict.get("d").toString());
         assertEquals("\\ \"", dict.get("e").toString());
     }
+
+    public void testParseNonAscii() throws Exception {
+        String asciiPropertyList = "{\n" +
+                "/* コメント */\n" +
+                "\"quoted\" = \"もじれつ\";\n" +
+                "\"not_quoted\" = クオート無し;\n" +
+                "\"with_escapes\" = \"\\\"\\\\\\\":\\n拡張文字ｷﾀｱｱｱ\";\n" +
+                "\"with_u_escapes\" = \"\\u0020\\u5e78\";\n" +
+                "}";
+        NSDictionary dict = (NSDictionary)ASCIIPropertyListParser.parse(asciiPropertyList.getBytes(Charset.forName("UTF-8")));
+        assertEquals("もじれつ", dict.get("quoted").toString());
+        assertEquals("クオート無し", dict.get("not_quoted").toString());
+        assertEquals("\"\\\":\n拡張文字ｷﾀｱｱｱ", dict.get("with_escapes").toString());
+        assertEquals("\u0020\u5e78", dict.get("with_u_escapes").toString());
+    }
 }


### PR DESCRIPTION
Currently, ASCIIPropertyListParser takes bytes[] and then pads the bytes
with an extra 00 byte to get UTF-16. If the byte is >= 0x80, then it
pads it with 0xff. This means that if the bytes are in the 7-bit ASCII
range, everything is fine. But if not, 0x80 for example becomes 0xff80,
(half-width TA katakana) which I don't believe corresponds to any real
encoding system.

The options are to:
 - convert using the default system encoding
 - convert using UTF-8

I think UTF-8 is a better default. The default system encoding is
good for backwards compatibility, but this feature (non-7-bit ASCII)
has never worked at all before, so that's not really necessary. This can
also be made configurable if the need presents itself.