### PR TITLE
Add support for POJO annotations

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,10 +64,19 @@ When you directly want to save your property list to a file, you can also use th
 
 For converting a file into another format there exist convenience methods in the `PropertyListParser` class: `convertToXML`, `convertToBinary`,  `convertToASCII` and `convertToGnuStepASCII`.
 
+### Annotations
+
+You may customize how Plain Old Java Objects (POJO) are serialized using the following annotations.
+
+  * Specify `@PlistOptions` at the top of your POJO class to denote that annotations will be used. Use `@PlistOptions(upperCamelCase = true)` to specify that all fields should be serialized in upper camel case mode, i.e., first letter is always an upper case letter.
+  * Use `@PlistIgnore` on a class field to omit it from serialization. Alternatively you may use the `transient` field modifier.
+  * Use `@PlistAlias` on a class field to specify how a field should be serialized to and deserialized from a XML property list file.
+
 ## Code snippets
 
 ### Reading
 
+```java
     try {
       File file = new File("Info.plist");
       NSDictionary rootDict = (NSDictionary)PropertyListParser.parse(file);
@@ -100,7 +109,7 @@ For converting a file into another format there exist convenience methods in the
     } catch(Exception ex) {
       ex.printStackTrace();
     }
-
+```
 
 #### On Android
 
@@ -108,6 +117,7 @@ Put your property list files into the project folder _res/raw_ to mark them as r
 
 In this example your property list file is called _properties.plist_.
 
+```java
     try {
       InputStream is = getResources().openRawResource(R.raw.properties);
       NSDictionary rootDict = (NSDictionary)PropertyListParser.parse(is);
@@ -115,9 +125,11 @@ In this example your property list file is called _properties.plist_.
     } catch(Exception ex) {
       //Handle exceptions...
     }
+```
 
 ### Writing
 
+```java
     //Creating the root object
     NSDictionary root = new NSDictionary();
 
@@ -151,3 +163,24 @@ In this example your property list file is called _properties.plist_.
 
     //Save the propery list
     PropertyListParser.saveAsXML(root, new File("people.plist"));
+```
+
+### Annotations
+
+```java
+    @PlistOptions(upperCamelCase = true)
+    public static class PayloadContent {
+        
+        private boolean allowAllAppsAccess = false; // serialized as '<key>AllowAllAppsAccess</key>'
+    
+        @PlistAlias("CAFingerprint")
+        private byte[] caFingerprint = new byte[]{};  // serialized as '<key>CAFingerprint</key>'
+        
+        @PlistAlias("Key Type")
+        private String keyType = "RSA";  // serialized as '<key>Key Type</key>'
+        
+        @PlistIgnore
+        private String ignored = "ignored";  // will not be serialized  
+        
+        private transient String ignored2 = "ignored2";  // will not be serialized
+```

--- a/README.md
+++ b/README.md
@@ -68,9 +68,10 @@ For converting a file into another format there exist convenience methods in the
 
 You may customize how Plain Old Java Objects (POJO) are serialized using the following annotations.
 
-  * Specify `@PlistOptions` at the top of your POJO class to denote that annotations will be used. Use `@PlistOptions(upperCamelCase = true)` to specify that all fields should be serialized in upper camel case mode, i.e., first letter is always an upper case letter.
+  * Specify `@PlistOptions` at the top of a class to denote that annotations will be used. Use `@PlistOptions(upperCamelCase = true)` to specify that all fields should be serialized in upper camel-case mode, i.e., first letter is always an upper case letter.
   * Use `@PlistIgnore` on a class field to omit it from serialization. Alternatively you may use the `transient` field modifier.
-  * Use `@PlistAlias` on a class field to specify how a field should be serialized to and deserialized from a XML property list file.
+  * Use `@PlistAlias` on a class field to specify the serialized name of a field.
+  * Use `@PlistInclude` on a class or field to specify how empty or `null` field values should be serialized.
 
 ## Code snippets
 
@@ -183,4 +184,16 @@ In this example your property list file is called _properties.plist_.
         private String ignored = "ignored";  // will not be serialized  
         
         private transient String ignored2 = "ignored2";  // will not be serialized
+
+        @PlistInclude(PlistInclude.Include.NON_EMPTY)
+        private String emptyText = "";  // will not be serialized  
+    
+        @PlistInclude(PlistInclude.Include.NON_EMPTY)
+        private byte[] emptyArray = new byte[]{};   // will not be serialized
+    
+        private byte[] emptyArrayIncluded = new byte[]{};   // serialized as '<key>EmptyArrayIncluded</key>'
+    
+        @PlistInclude(PlistInclude.Include.NON_NULL)
+        private Integer nullInt = null; // will not be serialized
+
 ```

--- a/src/main/java/com/dd/plist/NSObject.java
+++ b/src/main/java/com/dd/plist/NSObject.java
@@ -360,6 +360,10 @@ public abstract class NSObject implements Cloneable {
                     String aliasName = TextUtils.makeFirstCharLowerCase(alias.value());
                     String fieldName = field.getName();
 
+                    if (fieldName.startsWith("is")) {
+                        fieldName = TextUtils.makeFirstCharLowerCase(fieldName.substring(2));
+                    }
+
                     Method method = getters.get(fieldName);
                     if (method != null) {
                         getters.put(aliasName, method);

--- a/src/main/java/com/dd/plist/NSObject.java
+++ b/src/main/java/com/dd/plist/NSObject.java
@@ -731,7 +731,13 @@ public abstract class NSObject implements Cloneable {
                                     continue;
                                 }
                                 Class<?> valueClass = value.getClass();
+                                if (Collection.class.isAssignableFrom(valueClass) && ((Collection<?>) value).isEmpty()) {
+                                    continue;
+                                }
                                 if (valueClass.isArray() && Array.getLength(value) == 0) {
+                                    continue;
+                                }
+                                if (Map.class.isAssignableFrom(valueClass) && ((Map<?, ?>) value).isEmpty()) {
                                     continue;
                                 }
                                 break;

--- a/src/main/java/com/dd/plist/NSObject.java
+++ b/src/main/java/com/dd/plist/NSObject.java
@@ -29,7 +29,6 @@ import com.dd.plist.utils.ReflectionUtils;
 import com.dd.plist.utils.TextUtils;
 
 import java.io.IOException;
-import java.lang.annotation.Annotation;
 import java.lang.reflect.*;
 import java.util.*;
 
@@ -295,12 +294,6 @@ public abstract class NSObject implements Cloneable {
         }
     }
 
-    private static String makeFirstCharLowercase(String input) {
-        char[] chars = input.toCharArray();
-        chars[0] = Character.toLowerCase(chars[0]);
-        return new String(chars);
-    }
-
     private Object toJavaObject(NSObject payload, Class<?> clazz, Type[] types) {
         if (clazz.isArray()) {
             //generics and arrays do not mix
@@ -345,11 +338,11 @@ public abstract class NSObject implements Cloneable {
         for (Method method : clazz.getMethods()) {
             String name = method.getName();
             if (name.startsWith("get")) {
-                getters.put(makeFirstCharLowercase(name.substring(3)), method);
+                getters.put(TextUtils.makeFirstCharLowerCase(name.substring(3)), method);
             } else if (name.startsWith("set")) {
-                setters.put(makeFirstCharLowercase(name.substring(3)), method);
+                setters.put(TextUtils.makeFirstCharLowerCase(name.substring(3)), method);
             } else if (name.startsWith("is")) {
-                getters.put(makeFirstCharLowercase(name.substring(2)), method);
+                getters.put(TextUtils.makeFirstCharLowerCase(name.substring(2)), method);
             }
         }
 
@@ -362,7 +355,7 @@ public abstract class NSObject implements Cloneable {
 
                     if (field.isAnnotationPresent(PlistAlias.class)) {
                         PlistAlias alias = field.getAnnotation(PlistAlias.class);
-                        String aliasName = makeFirstCharLowercase(alias.value());
+                        String aliasName = TextUtils.makeFirstCharLowerCase(alias.value());
                         String fieldName = field.getName();
 
                         Method method = getters.get(fieldName);
@@ -380,8 +373,8 @@ public abstract class NSObject implements Cloneable {
         }
 
         for (Map.Entry<String, NSObject> entry : map.entrySet()) {
-            Method setter = setters.get(makeFirstCharLowercase(entry.getKey()));
-            Method getter = getters.get(makeFirstCharLowercase(entry.getKey()));
+            Method setter = setters.get(TextUtils.makeFirstCharLowerCase(entry.getKey()));
+            Method getter = getters.get(TextUtils.makeFirstCharLowerCase(entry.getKey()));
             if (setter != null && getter != null) {
                 Class<?> elemClass = getter.getReturnType();
                 Type[] elemTypes = null;
@@ -696,15 +689,13 @@ public abstract class NSObject implements Cloneable {
         throw new IllegalArgumentException("Cannot map " + objClass.getSimpleName() + " as a simple type.");
     }
 
-
     private static NSDictionary fromPojo(Object object, Class<?> objClass) {
         NSDictionary result = new NSDictionary();
 
         if (objClass.isAnnotationPresent(PlistOptions.class)) {
             PlistOptions options = objClass.getAnnotation(PlistOptions.class);
-            List<Field> fields = ReflectionUtils.getAllFields(objClass);
 
-            for (Field field : fields) {
+            for (Field field : ReflectionUtils.getAllFields(objClass)) {
                 int modifiers = field.getModifiers();
 
                 if (Modifier.isStatic(modifiers) || Modifier.isTransient(modifiers)
@@ -720,7 +711,7 @@ public abstract class NSObject implements Cloneable {
                 } else {
                     name = field.getName();
                     if (options.upperCamelCase() && name.length() > 1) {
-                        name = TextUtils.toUpperCase(name.charAt(0)) + name.substring(1);
+                        name = TextUtils.makeFirstCharUpperCase(name);
                     }
                 }
 
@@ -743,9 +734,9 @@ public abstract class NSObject implements Cloneable {
 
                 String name = method.getName();
                 if (name.startsWith("get")) {
-                    name = makeFirstCharLowercase(name.substring(3));
+                    name = TextUtils.makeFirstCharLowerCase(name.substring(3));
                 } else if (name.startsWith("is")) {
-                    name = makeFirstCharLowercase(name.substring(2));
+                    name = TextUtils.makeFirstCharLowerCase(name.substring(2));
                 } else {
                     ///not a getter
                     continue;

--- a/src/main/java/com/dd/plist/NSObject.java
+++ b/src/main/java/com/dd/plist/NSObject.java
@@ -2,7 +2,7 @@
  * plist - An open source library to parse and generate property lists
  * Copyright (C) 2014 Daniel Dreibrodt
  *
-* Permission is hereby granted, free of charge, to any person obtaining a copy
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
@@ -56,6 +56,7 @@ public abstract class NSObject implements Cloneable {
 
     /**
      * Creates and returns a deep copy of this instance.
+     *
      * @return A clone of this instance.
      */
     @Override
@@ -148,25 +149,26 @@ public abstract class NSObject implements Cloneable {
      * <li>{@link NSDate} objects are converted to {@link java.util.Date} objects.</li>
      * <li>{@link UID} objects are converted to byte arrays.</li>
      * </ul>
+     *
      * @return A native java object representing this NSObject's value.
      */
     public Object toJavaObject() {
-        if(this instanceof NSArray) {
+        if (this instanceof NSArray) {
             return this.deserializeArray();
         } else if (this instanceof NSDictionary) {
             return this.deserializeMap();
-        } else if(this instanceof NSSet) {
+        } else if (this instanceof NSSet) {
             return this.deserializeSet();
-        } else if(this instanceof NSNumber) {
+        } else if (this instanceof NSNumber) {
             return this.deserializeNumber();
-        } else if(this instanceof NSString) {
-            return ((NSString)this).getContent();
-        } else if(this instanceof NSData) {
-            return ((NSData)this).bytes();
-        } else if(this instanceof NSDate) {
-            return ((NSDate)this).getDate();
-        } else if(this instanceof UID) {
-            return ((UID)this).getBytes();
+        } else if (this instanceof NSString) {
+            return ((NSString) this).getContent();
+        } else if (this instanceof NSData) {
+            return ((NSData) this).bytes();
+        } else if (this instanceof NSDate) {
+            return ((NSDate) this).getDate();
+        } else if (this instanceof UID) {
+            return ((UID) this).getBytes();
         } else {
             return this;
         }
@@ -174,7 +176,8 @@ public abstract class NSObject implements Cloneable {
 
     /**
      * Converts this NSObject into an object of the specified class.
-     * @param <T> The target object type.
+     *
+     * @param <T>   The target object type.
      * @param clazz The target class.
      * @return A new instance of the specified class, deserialized from this NSObject.
      * @throws IllegalArgumentException If the specified class cannot be deserialized from this NSObject.
@@ -188,6 +191,7 @@ public abstract class NSObject implements Cloneable {
      * Serializes the specified object into an NSObject.
      * Objects which do not have a direct type correspondence to an NSObject type will be serialized as a {@link NSDictionary}.
      * The dictionary will contain the values of all publicly accessible fields and properties.
+     *
      * @param object The object to serialize.
      * @return A NSObject instance.
      * @throws IllegalArgumentException If the specified object throws an exception while getting its properties.
@@ -197,8 +201,8 @@ public abstract class NSObject implements Cloneable {
             return null;
         }
 
-        if(object instanceof NSObject) {
-            return (NSObject)object;
+        if (object instanceof NSObject) {
+            return (NSObject) object;
         }
 
         Class<?> objClass = object.getClass();
@@ -251,7 +255,7 @@ public abstract class NSObject implements Cloneable {
 
     private static Class<?> getClassForName(String className) {
         int spaceIndex = className.indexOf(' ');
-        if(spaceIndex != -1) {
+        if (spaceIndex != -1) {
             className = className.substring(spaceIndex + 1);
         }
 
@@ -366,9 +370,9 @@ public abstract class NSObject implements Cloneable {
     }
 
     private HashMap<String, Object> deserializeMap() {
-        HashMap<String, NSObject> originalMap = ((NSDictionary)this).getHashMap();
+        HashMap<String, NSObject> originalMap = ((NSDictionary) this).getHashMap();
         HashMap<String, Object> clonedMap = new HashMap<String, Object>(originalMap.size());
-        for(String key:originalMap.keySet()) {
+        for (String key : originalMap.keySet()) {
             clonedMap.put(key, originalMap.get(key).toJavaObject());
         }
 
@@ -450,9 +454,9 @@ public abstract class NSObject implements Cloneable {
     }
 
     private Object[] deserializeArray() {
-        NSObject[] originalArray = ((NSArray)this).getArray();
+        NSObject[] originalArray = ((NSArray) this).getArray();
         Object[] clonedArray = new Object[originalArray.length];
-        for(int i = 0; i < originalArray.length; i++) {
+        for (int i = 0; i < originalArray.length; i++) {
             clonedArray[i] = originalArray[i].toJavaObject();
         }
 
@@ -490,14 +494,14 @@ public abstract class NSObject implements Cloneable {
     }
 
     private Set<Object> deserializeSet() {
-        Set<NSObject> originalSet = ((NSSet)this).getSet();
+        Set<NSObject> originalSet = ((NSSet) this).getSet();
         Set<Object> clonedSet;
-        if(originalSet instanceof LinkedHashSet) {
+        if (originalSet instanceof LinkedHashSet) {
             clonedSet = new LinkedHashSet<Object>(originalSet.size());
         } else {
             clonedSet = new TreeSet<Object>();
         }
-        for(NSObject o : originalSet) {
+        for (NSObject o : originalSet) {
             clonedSet.add(o.toJavaObject());
         }
         return clonedSet;
@@ -553,23 +557,23 @@ public abstract class NSObject implements Cloneable {
     }
 
     private Object deserializeNumber() {
-        NSNumber num = (NSNumber)this;
-        switch(num.type()) {
-            case NSNumber.INTEGER : {
+        NSNumber num = (NSNumber) this;
+        switch (num.type()) {
+            case NSNumber.INTEGER: {
                 long longVal = num.longValue();
-                if(longVal > Integer.MAX_VALUE || longVal < Integer.MIN_VALUE) {
+                if (longVal > Integer.MAX_VALUE || longVal < Integer.MIN_VALUE) {
                     return longVal;
                 } else {
                     return num.intValue();
                 }
             }
-            case NSNumber.REAL : {
+            case NSNumber.REAL: {
                 return num.doubleValue();
             }
-            case NSNumber.BOOLEAN : {
+            case NSNumber.BOOLEAN: {
                 return num.boolValue();
             }
-            default : {
+            default: {
                 return num.doubleValue();
             }
         }
@@ -686,8 +690,8 @@ public abstract class NSObject implements Cloneable {
             }
         }
 
-        for(Field field : objClass.getFields()) {
-            if(Modifier.isStatic(field.getModifiers())) {
+        for (Field field : objClass.getFields()) {
+            if (Modifier.isStatic(field.getModifiers())) {
                 continue;
             }
 
@@ -715,7 +719,7 @@ public abstract class NSObject implements Cloneable {
 
     private static NSObject fromArray(Object object, Class<?> objClass) {
         Class<?> elementClass = objClass.getComponentType();
-        if(elementClass == byte.class || elementClass == Byte.class) {
+        if (elementClass == byte.class || elementClass == Byte.class) {
             return fromData(object);
         }
 
@@ -732,7 +736,7 @@ public abstract class NSObject implements Cloneable {
         int size = Array.getLength(object);
         byte[] array = new byte[size];
         for (int i = 0; i < size; i++) {
-            array[i] = (Byte)(Array.get(object, i));
+            array[i] = (Byte) (Array.get(object, i));
         }
 
         return new NSData(array);

--- a/src/main/java/com/dd/plist/NSObject.java
+++ b/src/main/java/com/dd/plist/NSObject.java
@@ -349,24 +349,24 @@ public abstract class NSObject implements Cloneable {
         if (clazz.isAnnotationPresent(PlistOptions.class)) {
             for (Field field : ReflectionUtils.getAllFields(clazz)) {
                 int modifiers = field.getModifiers();
+                if (Modifier.isStatic(modifiers) || Modifier.isTransient(modifiers)
+                        || field.isAnnotationPresent(PlistIgnore.class)) {
+                    continue;
+                }
 
-                if (!Modifier.isStatic(modifiers) && !Modifier.isTransient(modifiers)
-                        && !field.isAnnotationPresent(PlistIgnore.class)) {
+                if (field.isAnnotationPresent(PlistAlias.class)) {
+                    PlistAlias alias = field.getAnnotation(PlistAlias.class);
+                    String aliasName = TextUtils.makeFirstCharLowerCase(alias.value());
+                    String fieldName = field.getName();
 
-                    if (field.isAnnotationPresent(PlistAlias.class)) {
-                        PlistAlias alias = field.getAnnotation(PlistAlias.class);
-                        String aliasName = TextUtils.makeFirstCharLowerCase(alias.value());
-                        String fieldName = field.getName();
+                    Method method = getters.get(fieldName);
+                    if (method != null) {
+                        getters.put(aliasName, method);
+                    }
 
-                        Method method = getters.get(fieldName);
-                        if (method != null) {
-                            getters.put(aliasName, method);
-                        }
-
-                        method = setters.get(fieldName);
-                        if (method != null) {
-                            setters.put(aliasName, method);
-                        }
+                    method = setters.get(fieldName);
+                    if (method != null) {
+                        setters.put(aliasName, method);
                     }
                 }
             }
@@ -697,7 +697,6 @@ public abstract class NSObject implements Cloneable {
 
             for (Field field : ReflectionUtils.getAllFields(objClass)) {
                 int modifiers = field.getModifiers();
-
                 if (Modifier.isStatic(modifiers) || Modifier.isTransient(modifiers)
                         || field.isAnnotationPresent(PlistIgnore.class)) {
                     continue;

--- a/src/main/java/com/dd/plist/annotations/PlistAlias.java
+++ b/src/main/java/com/dd/plist/annotations/PlistAlias.java
@@ -1,0 +1,34 @@
+/*
+ * plist - An open source library to parse and generate property lists
+ * Copyright (C) 2014 Daniel Dreibrodt
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.dd.plist.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.FIELD})
+public @interface PlistAlias {
+    String value();
+}

--- a/src/main/java/com/dd/plist/annotations/PlistIgnore.java
+++ b/src/main/java/com/dd/plist/annotations/PlistIgnore.java
@@ -1,0 +1,34 @@
+/*
+ * plist - An open source library to parse and generate property lists
+ * Copyright (C) 2014 Daniel Dreibrodt
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.dd.plist.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.FIELD})
+public @interface PlistIgnore {
+}

--- a/src/main/java/com/dd/plist/annotations/PlistInclude.java
+++ b/src/main/java/com/dd/plist/annotations/PlistInclude.java
@@ -20,26 +20,35 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package com.dd.plist.utils;
 
-import java.lang.reflect.Field;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Objects;
+package com.dd.plist.annotations;
 
-public final class ReflectionUtils {
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
-    public static List<Field> getAllFields(Class<?> type) {
-        List<Field> fields = new ArrayList<Field>();
-        for (Class<?> c = type; c != null; c = c.getSuperclass()) {
-            fields.addAll(Arrays.asList(c.getDeclaredFields()));
-        }
-        return fields;
-    }
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.FIELD, ElementType.TYPE})
+public @interface PlistInclude {
 
-    public static Object getPrivateFieldValue(Field field, Object parent) throws IllegalAccessException {
-        field.setAccessible(true);
-        return field.get(parent);
+    /**
+     * Inclusion rule to use for instances (values) of annotated properties. Defaults to {@link Include#DEFAULT}.
+     */
+    Include value() default Include.DEFAULT;
+
+    enum Include {
+        /**
+         * Default behavior.
+         */
+        DEFAULT,
+        /**
+         * Only non-null values are to be included.
+         */
+        NON_NULL,
+        /**
+         * Only non-null values, non-empty strings and non-empty arrays are to be included.
+         */
+        NON_EMPTY
     }
 }

--- a/src/main/java/com/dd/plist/annotations/PlistOptions.java
+++ b/src/main/java/com/dd/plist/annotations/PlistOptions.java
@@ -1,0 +1,36 @@
+/*
+ * plist - An open source library to parse and generate property lists
+ * Copyright (C) 2014 Daniel Dreibrodt
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.dd.plist.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE})
+public @interface PlistOptions {
+
+    boolean upperCamelCase() default false;
+}

--- a/src/main/java/com/dd/plist/utils/ReflectionUtils.java
+++ b/src/main/java/com/dd/plist/utils/ReflectionUtils.java
@@ -30,7 +30,7 @@ import java.util.List;
 public final class ReflectionUtils {
 
     public static List<Field> getAllFields(Class<?> type) {
-        List<Field> fields = new ArrayList<>();
+        List<Field> fields = new ArrayList<Field>();
         for (Class<?> c = type; c != null; c = c.getSuperclass()) {
             fields.addAll(Arrays.asList(c.getDeclaredFields()));
         }

--- a/src/main/java/com/dd/plist/utils/ReflectionUtils.java
+++ b/src/main/java/com/dd/plist/utils/ReflectionUtils.java
@@ -1,0 +1,39 @@
+/*
+ * plist - An open source library to parse and generate property lists
+ * Copyright (C) 2014 Daniel Dreibrodt
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.dd.plist.utils;
+
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public final class ReflectionUtils {
+
+    public static List<Field> getAllFields(Class<?> type) {
+        List<Field> fields = new ArrayList<>();
+        for (Class<?> c = type; c != null; c = c.getSuperclass()) {
+            fields.addAll(Arrays.asList(c.getDeclaredFields()));
+        }
+        return fields;
+    }
+}

--- a/src/main/java/com/dd/plist/utils/TextUtils.java
+++ b/src/main/java/com/dd/plist/utils/TextUtils.java
@@ -29,8 +29,12 @@ public final class TextUtils {
      */
     private static final char CASE_MASK = 0x20;
 
-    public static char toUpperCase(char c) {
-        return isLowerCase(c) ? (char) (c ^ CASE_MASK) : c;
+    private static char toUpperCase(char c) {
+        return (char) (c ^ CASE_MASK);
+    }
+
+    private static char toLowerCase(char c) {
+        return (char) (c ^ CASE_MASK);
     }
 
     public static boolean isUpperCase(char c) {
@@ -39,5 +43,23 @@ public final class TextUtils {
 
     public static boolean isLowerCase(char c) {
         return (c >= 'a') && (c <= 'z');
+    }
+
+    public static String makeFirstCharLowerCase(String input) {
+        if (!isLowerCase(input.charAt(0))) {
+            char[] chars = input.toCharArray();
+            chars[0] = toLowerCase(chars[0]);
+            return new String(chars);
+        }
+        return input;
+    }
+
+    public static String makeFirstCharUpperCase(String input) {
+        if (!isUpperCase(input.charAt(0))) {
+            char[] chars = input.toCharArray();
+            chars[0] = toUpperCase(chars[0]);
+            return new String(chars);
+        }
+        return input;
     }
 }

--- a/src/main/java/com/dd/plist/utils/TextUtils.java
+++ b/src/main/java/com/dd/plist/utils/TextUtils.java
@@ -1,0 +1,43 @@
+/*
+ * plist - An open source library to parse and generate property lists
+ * Copyright (C) 2014 Daniel Dreibrodt
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.dd.plist.utils;
+
+public final class TextUtils {
+
+    /**
+     * A bit mask which selects the bit encoding ASCII character case.
+     */
+    private static final char CASE_MASK = 0x20;
+
+    public static char toUpperCase(char c) {
+        return isLowerCase(c) ? (char) (c ^ CASE_MASK) : c;
+    }
+
+    public static boolean isUpperCase(char c) {
+        return (c >= 'A') && (c <= 'Z');
+    }
+
+    public static boolean isLowerCase(char c) {
+        return (c >= 'a') && (c <= 'z');
+    }
+}

--- a/src/test/java/com/dd/plist/test/PlistAnnotationsTest.java
+++ b/src/test/java/com/dd/plist/test/PlistAnnotationsTest.java
@@ -24,6 +24,7 @@ public class PlistAnnotationsTest {
         testAppleSCEP.setIdentifier("com.apple.scep.test");
         testAppleSCEP.setUuid("test123");
         testAppleSCEP.setVersion(1);
+        testAppleSCEP.setPresent(true);
         TestAppleSCEP.TestAppleSCEPContent content = testAppleSCEP.getPayloadContent();
         content.setAllowAllAppsAccess(true);
         content.setChallenge("Challenge123");
@@ -104,6 +105,8 @@ public class PlistAnnotationsTest {
         assertFalse(xml.contains("<key>EmptyArray</key>"), "Must NOT BE present - 'EmptyArray'");
         assertTrue(xml.contains("<key>EmptyArrayIncluded</key>"), "Must be present - 'EmptyArrayIncluded'");
         assertFalse(xml.contains("<key>NullInt</key>"), "Must NOT BE present - 'NullInt'");
+        assertTrue(xml.contains("<key>IsPresent</key>"), "Must be present - 'IsPresent'");
+        assertTrue(xml.contains("<key>PresentIs</key>"), "Must be present - 'PresentIs'");
     }
 
     @Test
@@ -111,7 +114,7 @@ public class PlistAnnotationsTest {
         NSObject root = PropertyListParser.parse(new File("test-files/test-pojo-apple-scep-1.plist"));
 
         NSDictionary dict1 = (NSDictionary) root;
-        assertEquals(7, dict1.count());
+        assertEquals(9, dict1.count());
 
         NSDictionary dict2 = (NSDictionary) dict1.objectForKey("PayloadContent");
         assertEquals(8, dict2.count());

--- a/src/test/java/com/dd/plist/test/PlistAnnotationsTest.java
+++ b/src/test/java/com/dd/plist/test/PlistAnnotationsTest.java
@@ -62,10 +62,12 @@ public class PlistAnnotationsTest {
         String xml = NSObject.fromJavaObject(getTestSCEP1()).toXMLPropertyList();
 
         assertTrue(xml.contains("<key>PayloadContent</key>"), "UpperCamelCase Test - 'PayloadContent'");
-        assertFalse(xml.contains("<key>Ignored</key>"), "Ignored Test 'Ignored'");
         assertTrue(xml.contains("<key>AllowAllAppsAccess</key>"), "UpperCamelCase Test Subclass - 'AllowAllAppsAccess'");
         assertTrue(xml.contains("<key>CAFingerprint</key>"), "Alias Test Subclass - 'CAFingerprint'");
         assertTrue(xml.contains("<key>PayloadDisplayName</key>"), "Alias + Subclass Test - 'PayloadDisplayName'");
+        assertFalse(xml.contains("<key>Ignored</key>"), "No annotated 'Ignored'");
+        assertFalse(xml.contains("<key>IgnoredTransient</key>"), "No transient - 'IgnoredTransient'");
+        assertFalse(xml.contains("<key>IgnoredStatic</key>"), "No static - 'IgnoredStatic'");
     }
 
     @Test

--- a/src/test/java/com/dd/plist/test/PlistAnnotationsTest.java
+++ b/src/test/java/com/dd/plist/test/PlistAnnotationsTest.java
@@ -73,6 +73,10 @@ public class PlistAnnotationsTest {
         assertFalse(xml.contains("<key>emptyText</key>"), "Must NOT BE present - 'emptyText'");
         assertFalse(xml.contains("<key>emptyArray</key>"), "Must NOT BE present - 'emptyArray'");
         assertFalse(xml.contains("<key>nullInt</key>"), "Must NOT BE present - 'nullInt'");
+        assertFalse(xml.contains("<key>emptyList</key>"), "Must NOT BE present - 'emptyList'");
+        assertFalse(xml.contains("<key>emptySet</key>"), "Must NOT BE present - 'emptySet'");
+        assertFalse(xml.contains("<key>emptyMap</key>"), "Must NOT BE present - 'emptyMap'");
+        assertTrue(xml.contains("<key>col</key>"), "Must be present - 'col'");
 
         xml = NSObject.fromJavaObject(new TestAnnotationsClass2()).toXMLPropertyList();
 

--- a/src/test/java/com/dd/plist/test/PlistAnnotationsTest.java
+++ b/src/test/java/com/dd/plist/test/PlistAnnotationsTest.java
@@ -1,0 +1,107 @@
+package com.dd.plist.test;
+
+import com.dd.plist.NSDictionary;
+import com.dd.plist.NSObject;
+import com.dd.plist.PropertyListParser;
+import com.dd.plist.test.model.TestAppleSCEP;
+import com.sun.tools.javac.util.List;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class PlistAnnotationsTest {
+
+    public static InputStream getResource(String filename) throws IOException {
+        final String fullname = "/" + filename;
+        final InputStream input = PlistAnnotationsTest.class.getResourceAsStream(fullname);
+        if (input == null)
+            throw new IOException(fullname + " cannot be loaded!");
+        return input;
+    }
+
+    public TestAppleSCEP getTestSCEP1() {
+        TestAppleSCEP testAppleSCEP = new TestAppleSCEP();
+        testAppleSCEP.setDescription("This is description");
+        testAppleSCEP.setDisplayName("Apple SCEP");
+        testAppleSCEP.setIdentifier("com.apple.scep.test");
+        testAppleSCEP.setUuid("test123");
+        testAppleSCEP.setVersion(1);
+        TestAppleSCEP.TestAppleSCEPContent content = testAppleSCEP.getPayloadContent();
+        content.setAllowAllAppsAccess(true);
+        content.setChallenge("Challenge123");
+        content.setKeyType("RSA");
+        content.setKeyUsage(4);
+        content.setRetries(10);
+        content.setSubject(List.of(List.of(List.of("C", "US")), List.of(List.of("O", "DEV"))));
+        content.setCaFingerprint(new byte[]{23, 31, 53, 89, 99, -23, -12, 42, 120, -42, -78, 21, 23, 31, 53, 89, 99, -23, -12, 42, 120, -42, -78, 21, 23, 31, 53, 89, 99, -23, -12, 42, 120, -42, -78, 21, 23, 31, 53, 89, 99, -23, -12, 42, 120, -42, -78, 21, 2, 1, 0, 42, -12, 0, 2});
+        return testAppleSCEP;
+    }
+
+    public TestAppleSCEP getTestSCEP2() {
+        TestAppleSCEP testAppleSCEP = new TestAppleSCEP();
+        testAppleSCEP.setDescription("Configures SCEP settings");
+        testAppleSCEP.setDisplayName("SCEP");
+        testAppleSCEP.setIdentifier("com.apple.security.scep.3B61BAE9-B049-4B89-8373-545A2DAD5136");
+        testAppleSCEP.setUuid("3B61BAE9-B049-4B89-8373-545A2DAD5136");
+        testAppleSCEP.setVersion(1);
+        TestAppleSCEP.TestAppleSCEPContent content = testAppleSCEP.getPayloadContent();
+        content.setChallenge("123");
+        content.setKeyType("RSA");
+        content.setKeySize(2048);
+        content.setRetries(3);
+        content.setSubject(List.of(List.of(List.of("Test Sung"))));
+        return testAppleSCEP;
+    }
+
+    @Test
+    public void testSerializePojo() {
+        String xml = NSObject.fromJavaObject(getTestSCEP1()).toXMLPropertyList();
+
+        assertTrue(xml.contains("<key>PayloadContent</key>"), "UpperCamelCase Test - 'PayloadContent'");
+        assertFalse(xml.contains("<key>Ignored</key>"), "Ignored Test 'Ignored'");
+        assertTrue(xml.contains("<key>AllowAllAppsAccess</key>"), "UpperCamelCase Test Subclass - 'AllowAllAppsAccess'");
+        assertTrue(xml.contains("<key>CAFingerprint</key>"), "Alias Test Subclass - 'CAFingerprint'");
+        assertTrue(xml.contains("<key>PayloadDisplayName</key>"), "Alias + Subclass Test - 'PayloadDisplayName'");
+    }
+
+    @Test
+    public void testDeserializePojo_apple_scep_1() throws Exception {
+        NSObject root = PropertyListParser.parse(new File("test-files/test-pojo-apple-scep-1.plist"));
+
+        NSDictionary dict1 = (NSDictionary) root;
+        assertEquals(7, dict1.count());
+
+        NSDictionary dict2 = (NSDictionary) dict1.objectForKey("PayloadContent");
+        assertEquals(8, dict2.count());
+
+        assertTrue(dict2.containsKey("AllowAllAppsAccess"), "contains 'AllowAllAppsAccess'");
+        assertTrue(dict2.containsKey("CAFingerprint"), "contains 'CAFingerprint'");
+        assertTrue(dict2.containsKey("Subject"), "contains 'Subject'");
+
+        TestAppleSCEP deserialized = root.toJavaObject(TestAppleSCEP.class);
+        assertEquals(getTestSCEP1(), deserialized, "deserialized plist file");
+    }
+
+    @Test
+    public void testDeserializePojo_apple_scep_2() throws Exception {
+        // test a payload generated with Apple Configurator
+        NSObject root = PropertyListParser.parse(new File("test-files/test-pojo-apple-scep-2.plist"));
+
+        NSDictionary dict1 = (NSDictionary) root;
+        assertEquals(7, dict1.count());
+
+        NSDictionary dict2 = (NSDictionary) dict1.objectForKey("PayloadContent");
+        assertEquals(9, dict2.count());
+
+        assertTrue(dict2.containsKey("URL"), "contains 'URL'");
+        assertTrue(dict2.containsKey("SubjectAltName"), "contains 'SubjectAltName'");
+        assertTrue(dict2.containsKey("Subject"), "contains 'Subject'");
+
+        TestAppleSCEP deserialized = root.toJavaObject(TestAppleSCEP.class);
+        assertEquals(getTestSCEP2(), deserialized, "deserialized plist file");
+    }
+}

--- a/src/test/java/com/dd/plist/test/model/TestAnnotationsClass1.java
+++ b/src/test/java/com/dd/plist/test/model/TestAnnotationsClass1.java
@@ -1,0 +1,27 @@
+package com.dd.plist.test.model;
+
+import com.dd.plist.annotations.PlistAlias;
+import com.dd.plist.annotations.PlistIgnore;
+import com.dd.plist.annotations.PlistInclude;
+import com.dd.plist.annotations.PlistOptions;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+
+@PlistOptions
+@PlistInclude(PlistInclude.Include.NON_EMPTY)
+public class TestAnnotationsClass1 {
+
+    private String emptyText = "";
+
+    private String textIncluded = "textIncluded";
+
+    private byte[] emptyArray = new byte[]{};
+
+    private byte[] arrayIncluded = new byte[]{17, 56, 0};
+
+    private Integer nullInt = null;
+
+}

--- a/src/test/java/com/dd/plist/test/model/TestAnnotationsClass1.java
+++ b/src/test/java/com/dd/plist/test/model/TestAnnotationsClass1.java
@@ -5,10 +5,7 @@ import com.dd.plist.annotations.PlistIgnore;
 import com.dd.plist.annotations.PlistInclude;
 import com.dd.plist.annotations.PlistOptions;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Objects;
+import java.util.*;
 
 @PlistOptions
 @PlistInclude(PlistInclude.Include.NON_EMPTY)
@@ -23,5 +20,13 @@ public class TestAnnotationsClass1 {
     private byte[] arrayIncluded = new byte[]{17, 56, 0};
 
     private Integer nullInt = null;
+
+    private List<String> emptyList = new ArrayList<>();
+
+    private Set<String> emptySet = new HashSet<>();
+
+    private Map<String, String> emptyMap = new HashMap<>();
+
+    private Collection<String> col = Collections.singletonList("TEST");
 
 }

--- a/src/test/java/com/dd/plist/test/model/TestAnnotationsClass2.java
+++ b/src/test/java/com/dd/plist/test/model/TestAnnotationsClass2.java
@@ -1,0 +1,21 @@
+package com.dd.plist.test.model;
+
+import com.dd.plist.annotations.PlistInclude;
+import com.dd.plist.annotations.PlistOptions;
+
+@PlistOptions
+@PlistInclude(PlistInclude.Include.NON_NULL)
+public class TestAnnotationsClass2 {
+
+    private String nullText = null;
+
+    private String emptyText = "";
+
+    private String textIncluded = "textIncluded";
+
+    private byte[] emptyArray = new byte[]{};
+
+    private byte[] arrayIncluded = new byte[]{17, 56, 0};
+
+    private byte[] nullArray = null;
+}

--- a/src/test/java/com/dd/plist/test/model/TestAppleAbstract.java
+++ b/src/test/java/com/dd/plist/test/model/TestAppleAbstract.java
@@ -1,0 +1,98 @@
+package com.dd.plist.test.model;
+
+import com.dd.plist.annotations.PlistAlias;
+import com.dd.plist.annotations.PlistOptions;
+
+import java.util.Objects;
+
+@PlistOptions
+public class TestAppleAbstract {
+
+    @PlistAlias("PayloadType")
+    private String type;
+    @PlistAlias("PayloadVersion")
+    private int version;
+    @PlistAlias("PayloadIdentifier")
+    private String identifier;
+    @PlistAlias("PayloadUUID")
+    private String uuid;
+    @PlistAlias("PayloadDisplayName")
+    private String displayName;
+    @PlistAlias("PayloadDescription")
+    private String description;
+    @PlistAlias("PayloadOrganization")
+    private String organization;
+
+    public TestAppleAbstract(String type) {
+        this.type = type;
+    }
+
+    public String getType() {
+        return this.type;
+    }
+
+    public int getVersion() {
+        return this.version;
+    }
+
+    public void setVersion(int version) {
+        this.version = version;
+    }
+
+    public String getIdentifier() {
+        return this.identifier;
+    }
+
+    public void setIdentifier(String identifier) {
+        this.identifier = identifier;
+    }
+
+    public String getUuid() {
+        return this.uuid;
+    }
+
+    public void setUuid(String uuid) {
+        this.uuid = uuid;
+    }
+
+    public String getDisplayName() {
+        return this.displayName;
+    }
+
+    public void setDisplayName(String displayName) {
+        this.displayName = displayName;
+    }
+
+    public String getDescription() {
+        return this.description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public String getOrganization() {
+        return this.organization;
+    }
+
+    public void setOrganization(String organization) {
+        this.organization = organization;
+    }
+
+    @Override public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || this.getClass() != o.getClass()) return false;
+        TestAppleAbstract that = (TestAppleAbstract) o;
+        return this.version == that.version &&
+                Objects.equals(this.type, that.type) &&
+                Objects.equals(this.identifier, that.identifier) &&
+                Objects.equals(this.uuid, that.uuid) &&
+                Objects.equals(this.displayName, that.displayName) &&
+                Objects.equals(this.description, that.description) &&
+                Objects.equals(this.organization, that.organization);
+    }
+
+    @Override public int hashCode() {
+        return Objects.hash(this.type, this.version, this.identifier, this.uuid, this.displayName, this.description, this.organization);
+    }
+}

--- a/src/test/java/com/dd/plist/test/model/TestAppleSCEP.java
+++ b/src/test/java/com/dd/plist/test/model/TestAppleSCEP.java
@@ -33,10 +33,31 @@ public class TestAppleSCEP extends TestAppleAbstract {
     @PlistInclude(PlistInclude.Include.NON_NULL)
     private Integer nullInt = null;
 
+    @PlistAlias("IsPresent")
+    private Boolean isPresent = null;
+
+    private boolean presentIs = false;
+
     private TestAppleSCEPContent payloadContent = new TestAppleSCEPContent();
 
     public TestAppleSCEP() {
         super("com.apple.security.scep");
+    }
+
+    public Boolean getPresent() {
+        return this.isPresent;
+    }
+
+    public void setPresent(Boolean present) {
+        this.isPresent = present;
+    }
+
+    public boolean isPresentIs() {
+        return this.presentIs;
+    }
+
+    public void setPresentIs(boolean presentIs) {
+        this.presentIs = presentIs;
     }
 
     public TestAppleSCEPContent getPayloadContent() {
@@ -152,18 +173,20 @@ public class TestAppleSCEP extends TestAppleAbstract {
         if (o == null || this.getClass() != o.getClass()) return false;
         if (!super.equals(o)) return false;
         TestAppleSCEP that = (TestAppleSCEP) o;
-        return Objects.equals(this.ignoredTransient, that.ignoredTransient) &&
+        return this.presentIs == that.presentIs &&
+                Objects.equals(this.ignoredTransient, that.ignoredTransient) &&
                 Objects.equals(this.ignored, that.ignored) &&
                 Objects.equals(this.emptyTextIncluded, that.emptyTextIncluded) &&
                 Objects.equals(this.emptyText, that.emptyText) &&
                 Arrays.equals(this.emptyArray, that.emptyArray) &&
                 Arrays.equals(this.emptyArrayIncluded, that.emptyArrayIncluded) &&
                 Objects.equals(this.nullInt, that.nullInt) &&
+                Objects.equals(this.isPresent, that.isPresent) &&
                 Objects.equals(this.payloadContent, that.payloadContent);
     }
 
     @Override public int hashCode() {
-        int result = Objects.hash(super.hashCode(), this.ignoredTransient, this.ignored, this.emptyTextIncluded, this.emptyText, this.nullInt, this.payloadContent);
+        int result = Objects.hash(super.hashCode(), this.ignoredTransient, this.ignored, this.emptyTextIncluded, this.emptyText, this.nullInt, this.isPresent, this.presentIs, this.payloadContent);
         result = 31 * result + Arrays.hashCode(this.emptyArray);
         result = 31 * result + Arrays.hashCode(this.emptyArrayIncluded);
         return result;

--- a/src/test/java/com/dd/plist/test/model/TestAppleSCEP.java
+++ b/src/test/java/com/dd/plist/test/model/TestAppleSCEP.java
@@ -1,0 +1,144 @@
+package com.dd.plist.test.model;
+
+import com.dd.plist.annotations.PlistAlias;
+import com.dd.plist.annotations.PlistIgnore;
+import com.dd.plist.annotations.PlistOptions;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+
+@PlistOptions(upperCamelCase = true)
+public class TestAppleSCEP extends TestAppleAbstract {
+
+    private TestAppleSCEPContent payloadContent = new TestAppleSCEPContent();
+
+    @PlistIgnore
+    private String ignored = "ignored";
+
+    public TestAppleSCEP() {
+        super("com.apple.security.scep");
+    }
+
+    public TestAppleSCEPContent getPayloadContent() {
+        return this.payloadContent;
+    }
+
+    public void setPayloadContent(TestAppleSCEPContent payloadContent) {
+        this.payloadContent = payloadContent;
+    }
+
+    @PlistOptions(upperCamelCase = true)
+    public static class TestAppleSCEPContent {
+        private boolean allowAllAppsAccess = false;
+        @PlistAlias("CAFingerprint")
+        private byte[] caFingerprint = new byte[]{};
+        private String challenge = "";
+        @PlistAlias("Key Type")
+        private String keyType = "RSA";
+        @PlistAlias("Key Usage")
+        private int keyUsage = 0;
+        @PlistAlias("Keysize")
+        private int keySize = 0;
+        private int retries = 3;
+        private List<List<List<String>>> subject = new ArrayList<>();
+
+        public boolean isAllowAllAppsAccess() {
+            return this.allowAllAppsAccess;
+        }
+
+        public void setAllowAllAppsAccess(boolean allowAllAppsAccess) {
+            this.allowAllAppsAccess = allowAllAppsAccess;
+        }
+
+        public byte[] getCaFingerprint() {
+            return this.caFingerprint;
+        }
+
+        public void setCaFingerprint(byte[] caFingerprint) {
+            this.caFingerprint = caFingerprint;
+        }
+
+        public String getChallenge() {
+            return this.challenge;
+        }
+
+        public void setChallenge(String challenge) {
+            this.challenge = challenge;
+        }
+
+        public String getKeyType() {
+            return this.keyType;
+        }
+
+        public void setKeyType(String keyType) {
+            this.keyType = keyType;
+        }
+
+        public int getKeyUsage() {
+            return this.keyUsage;
+        }
+
+        public void setKeyUsage(int keyUsage) {
+            this.keyUsage = keyUsage;
+        }
+
+        public int getKeySize() {
+            return this.keySize;
+        }
+
+        public void setKeySize(int keySize) {
+            this.keySize = keySize;
+        }
+
+        public int getRetries() {
+            return this.retries;
+        }
+
+        public void setRetries(int retries) {
+            this.retries = retries;
+        }
+
+        public List<List<List<String>>> getSubject() {
+            return this.subject;
+        }
+
+        public void setSubject(List<List<List<String>>> subject) {
+            this.subject = subject;
+        }
+
+        @Override public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || this.getClass() != o.getClass()) return false;
+            TestAppleSCEPContent that = (TestAppleSCEPContent) o;
+            return this.allowAllAppsAccess == that.allowAllAppsAccess &&
+                    this.keyUsage == that.keyUsage &&
+                    this.keySize == that.keySize &&
+                    this.retries == that.retries &&
+                    Arrays.equals(this.caFingerprint, that.caFingerprint) &&
+                    Objects.equals(this.challenge, that.challenge) &&
+                    Objects.equals(this.keyType, that.keyType) &&
+                    Objects.equals(this.subject, that.subject);
+        }
+
+        @Override public int hashCode() {
+            int result = Objects.hash(this.allowAllAppsAccess, this.challenge, this.keyType, this.keyUsage, this.keySize, this.retries, this.subject);
+            result = 31 * result + Arrays.hashCode(this.caFingerprint);
+            return result;
+        }
+    }
+
+    @Override public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || this.getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+        TestAppleSCEP that = (TestAppleSCEP) o;
+        return Objects.equals(this.payloadContent, that.payloadContent) &&
+                Objects.equals(this.ignored, that.ignored);
+    }
+
+    @Override public int hashCode() {
+        return Objects.hash(super.hashCode(), this.payloadContent, this.ignored);
+    }
+}

--- a/src/test/java/com/dd/plist/test/model/TestAppleSCEP.java
+++ b/src/test/java/com/dd/plist/test/model/TestAppleSCEP.java
@@ -2,6 +2,7 @@ package com.dd.plist.test.model;
 
 import com.dd.plist.annotations.PlistAlias;
 import com.dd.plist.annotations.PlistIgnore;
+import com.dd.plist.annotations.PlistInclude;
 import com.dd.plist.annotations.PlistOptions;
 
 import java.util.ArrayList;
@@ -18,6 +19,19 @@ public class TestAppleSCEP extends TestAppleAbstract {
 
     @PlistIgnore
     private String ignored = "ignored";
+
+    private String emptyTextIncluded = "";
+
+    @PlistInclude(PlistInclude.Include.NON_EMPTY)
+    private String emptyText = "";
+
+    @PlistInclude(PlistInclude.Include.NON_EMPTY)
+    private byte[] emptyArray = new byte[]{};
+
+    private byte[] emptyArrayIncluded = new byte[]{};
+
+    @PlistInclude(PlistInclude.Include.NON_NULL)
+    private Integer nullInt = null;
 
     private TestAppleSCEPContent payloadContent = new TestAppleSCEPContent();
 
@@ -139,11 +153,19 @@ public class TestAppleSCEP extends TestAppleAbstract {
         if (!super.equals(o)) return false;
         TestAppleSCEP that = (TestAppleSCEP) o;
         return Objects.equals(this.ignoredTransient, that.ignoredTransient) &&
-                Objects.equals(this.payloadContent, that.payloadContent) &&
-                Objects.equals(this.ignored, that.ignored);
+                Objects.equals(this.ignored, that.ignored) &&
+                Objects.equals(this.emptyTextIncluded, that.emptyTextIncluded) &&
+                Objects.equals(this.emptyText, that.emptyText) &&
+                Arrays.equals(this.emptyArray, that.emptyArray) &&
+                Arrays.equals(this.emptyArrayIncluded, that.emptyArrayIncluded) &&
+                Objects.equals(this.nullInt, that.nullInt) &&
+                Objects.equals(this.payloadContent, that.payloadContent);
     }
 
     @Override public int hashCode() {
-        return Objects.hash(super.hashCode(), this.ignoredTransient, this.payloadContent, this.ignored);
+        int result = Objects.hash(super.hashCode(), this.ignoredTransient, this.ignored, this.emptyTextIncluded, this.emptyText, this.nullInt, this.payloadContent);
+        result = 31 * result + Arrays.hashCode(this.emptyArray);
+        result = 31 * result + Arrays.hashCode(this.emptyArrayIncluded);
+        return result;
     }
 }

--- a/src/test/java/com/dd/plist/test/model/TestAppleSCEP.java
+++ b/src/test/java/com/dd/plist/test/model/TestAppleSCEP.java
@@ -12,10 +12,14 @@ import java.util.Objects;
 @PlistOptions(upperCamelCase = true)
 public class TestAppleSCEP extends TestAppleAbstract {
 
-    private TestAppleSCEPContent payloadContent = new TestAppleSCEPContent();
+    private static String ignoredStatic = "ignoredStatic";
+
+    private transient String ignoredTransient = "ignoredTransient";
 
     @PlistIgnore
     private String ignored = "ignored";
+
+    private TestAppleSCEPContent payloadContent = new TestAppleSCEPContent();
 
     public TestAppleSCEP() {
         super("com.apple.security.scep");
@@ -134,11 +138,12 @@ public class TestAppleSCEP extends TestAppleAbstract {
         if (o == null || this.getClass() != o.getClass()) return false;
         if (!super.equals(o)) return false;
         TestAppleSCEP that = (TestAppleSCEP) o;
-        return Objects.equals(this.payloadContent, that.payloadContent) &&
+        return Objects.equals(this.ignoredTransient, that.ignoredTransient) &&
+                Objects.equals(this.payloadContent, that.payloadContent) &&
                 Objects.equals(this.ignored, that.ignored);
     }
 
     @Override public int hashCode() {
-        return Objects.hash(super.hashCode(), this.payloadContent, this.ignored);
+        return Objects.hash(super.hashCode(), this.ignoredTransient, this.payloadContent, this.ignored);
     }
 }

--- a/test-files/test-pojo-apple-scep-1.plist
+++ b/test-files/test-pojo-apple-scep-1.plist
@@ -29,6 +29,10 @@
                 </array>
             </array>
         </dict>
+        <key>IsPresent</key>
+        <true/>
+        <key>PresentIs</key>
+        <false/>
         <key>PayloadType</key>
         <string>com.apple.security.scep</string>
         <key>PayloadVersion</key>

--- a/test-files/test-pojo-apple-scep-1.plist
+++ b/test-files/test-pojo-apple-scep-1.plist
@@ -24,14 +24,7 @@
             <array>
                 <array>
                     <array>
-                        <string>C</string>
-                        <string>US</string>
-                    </array>
-                </array>
-                <array>
-                    <array>
-                        <string>O</string>
-                        <string>DEV</string>
+                        <string>Test Sung</string>
                     </array>
                 </array>
             </array>

--- a/test-files/test-pojo-apple-scep-1.plist
+++ b/test-files/test-pojo-apple-scep-1.plist
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+    <dict>
+        <key>PayloadContent</key>
+        <dict>
+            <key>AllowAllAppsAccess</key>
+            <true/>
+            <key>CAFingerprint</key>
+            <data>
+                Fx81WWPp9Cp41rIVFx81WWPp9Cp41rIVFx81WWPp9Cp41rIVFx81WWPp9Cp41rIVAgEAKvQAAg==
+            </data>
+            <key>Challenge</key>
+            <string>Challenge123</string>
+            <key>Key Type</key>
+            <string>RSA</string>
+            <key>Key Usage</key>
+            <integer>4</integer>
+            <key>Keysize</key>
+            <integer>0</integer>
+            <key>Retries</key>
+            <integer>10</integer>
+            <key>Subject</key>
+            <array>
+                <array>
+                    <array>
+                        <string>C</string>
+                        <string>US</string>
+                    </array>
+                </array>
+                <array>
+                    <array>
+                        <string>O</string>
+                        <string>DEV</string>
+                    </array>
+                </array>
+            </array>
+        </dict>
+        <key>PayloadType</key>
+        <string>com.apple.security.scep</string>
+        <key>PayloadVersion</key>
+        <integer>1</integer>
+        <key>PayloadIdentifier</key>
+        <string>com.apple.scep.test</string>
+        <key>PayloadUUID</key>
+        <string>test123</string>
+        <key>PayloadDisplayName</key>
+        <string>Apple SCEP</string>
+        <key>PayloadDescription</key>
+        <string>This is description</string>
+    </dict>
+</plist>

--- a/test-files/test-pojo-apple-scep-2.plist
+++ b/test-files/test-pojo-apple-scep-2.plist
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+    <dict>
+        <key>PayloadContent</key>
+        <dict>
+            <key>Challenge</key>
+            <string>123</string>
+            <key>Key Type</key>
+            <string>RSA</string>
+            <key>Keysize</key>
+            <integer>2048</integer>
+            <key>Name</key>
+            <string>SCEP NAME</string>
+            <key>Retries</key>
+            <integer>3</integer>
+            <key>RetryDelay</key>
+            <integer>10</integer>
+            <key>Subject</key>
+            <array>
+                <array>
+                    <array>
+                        <string>Test Sung</string>
+                    </array>
+                </array>
+            </array>
+            <key>SubjectAltName</key>
+            <dict>
+                <key>rfc822Name</key>
+                <string>TEST</string>
+            </dict>
+            <key>URL</key>
+            <string>https://server</string>
+        </dict>
+        <key>PayloadDescription</key>
+        <string>Configures SCEP settings</string>
+        <key>PayloadDisplayName</key>
+        <string>SCEP</string>
+        <key>PayloadIdentifier</key>
+        <string>com.apple.security.scep.3B61BAE9-B049-4B89-8373-545A2DAD5136</string>
+        <key>PayloadType</key>
+        <string>com.apple.security.scep</string>
+        <key>PayloadUUID</key>
+        <string>3B61BAE9-B049-4B89-8373-545A2DAD5136</string>
+        <key>PayloadVersion</key>
+        <integer>1</integer>
+    </dict>
+</plist>

--- a/test-files/test-pojo-apple-scep-2.plist
+++ b/test-files/test-pojo-apple-scep-2.plist
@@ -20,7 +20,14 @@
             <array>
                 <array>
                     <array>
-                        <string>Test Sung</string>
+                        <string>C</string>
+                        <string>US</string>
+                    </array>
+                </array>
+                <array>
+                    <array>
+                        <string>O</string>
+                        <string>DEV</string>
                     </array>
                 </array>
             </array>


### PR DESCRIPTION
This PR adds support for annotations when serializing and deserializing Java classes. I needed this in a project I'm working on that creates/parses [Apple Configurator](https://support.apple.com/apple-configurator) Plist config files.

I did not want to introduce potential breaking changes in the already existing Pojo serialization code, therefore the new functionality I have added is only enforceable when the `@PlistOptions` annotation is denoted on a Java class. 

Here's a short documentation, also included in the README file.

  * Specify `@PlistOptions` at the top of a class to denote that annotations will be used. Use `@PlistOptions(upperCamelCase = true)` to specify that all fields should be serialized in upper camel-case mode, i.e., first letter is always an upper case letter.
  * Use `@PlistIgnore` on a class field to omit it from serialization. Alternatively you may use the `transient` field modifier.
  * Use `@PlistAlias` on a class field to specify the serialized name of a field.
  * Use `@PlistInclude` on a class or field to specify how empty or `null` field values should be serialized.

Feedback is welcome. Cheers 🍺 
