### PR TITLE
XML and ASCII parser improvements for reading data from String/Reader

### DIFF
--- a/src/main/java/com/dd/plist/ASCIIPropertyListParser.java
+++ b/src/main/java/com/dd/plist/ASCIIPropertyListParser.java
@@ -22,10 +22,12 @@
  */
 package com.dd.plist;
 
+import java.io.CharArrayWriter;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.Reader;
 import java.io.UnsupportedEncodingException;
 import java.text.ParseException;
 import java.text.StringCharacterIterator;
@@ -110,7 +112,17 @@ public final class ASCIIPropertyListParser {
      * @throws java.io.UnsupportedEncodingException If no support for the named charset is available in this instance of the Java virtual machine.
      */
     private ASCIIPropertyListParser(byte[] propertyListContent, String encoding) throws UnsupportedEncodingException {
-        this.data = new String(propertyListContent, encoding).toCharArray();
+        this(new String(propertyListContent, encoding).toCharArray());
+    }
+
+    /**
+     * Creates a new parser for the given property list content.
+     *
+     * @param propertyListContent The content of the property list that is to be parsed.
+     * @throws java.io.UnsupportedEncodingException If no support for the named charset is available in this instance of the Java virtual machine.
+     */
+    private ASCIIPropertyListParser(char[] propertyListContent) throws UnsupportedEncodingException {
+        this.data = propertyListContent;
     }
 
     /**
@@ -170,6 +182,39 @@ public final class ASCIIPropertyListParser {
      */
     public static NSObject parse(InputStream in) throws ParseException, IOException {
         return parse(PropertyListParser.readAll(in));
+    }
+
+    /**
+     * Parses an ASCII property list from an input reader.
+     * This method does not close the specified input reader.
+     *
+     * @param reader The input reader that points to the property list's data.
+     * @return The root object of the property list. This is usually a {@link NSDictionary} but can also be a {@link NSArray}.
+     * @throws java.text.ParseException If an error occurs during parsing.
+     * @throws java.io.IOException      If an error occurs while reading from the input reader.
+     */
+    public static NSObject parse(Reader reader) throws ParseException, IOException {
+        CharArrayWriter charArrayWriter = new CharArrayWriter();
+        char[] buf = new char[4096];
+        int read;
+        while ((read = reader.read(buf)) >= 0) {
+            charArrayWriter.write(buf, 0, read);
+        }
+        ASCIIPropertyListParser parser = new ASCIIPropertyListParser(charArrayWriter.toCharArray());
+        return parser.parse();
+    }
+
+    /**
+     * Parses an ASCII property list from an {@link String}
+     *
+     * @param plistData A String containing property list's data.
+     * @return The root object of the property list. This is usually a {@link NSDictionary} but can also be a {@link NSArray}.
+     * @throws java.text.ParseException If an error occurs during parsing.
+     * @throws java.io.IOException      If an error occurs while reading from the input reader.
+     */
+    public static NSObject parse(String plistData) throws ParseException, IOException {
+        ASCIIPropertyListParser parser = new ASCIIPropertyListParser(plistData.toCharArray());
+        return parser.parse();
     }
 
     /**

--- a/src/main/java/com/dd/plist/PropertyListParser.java
+++ b/src/main/java/com/dd/plist/PropertyListParser.java
@@ -36,6 +36,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.text.ParseException;
 
 /**
@@ -54,7 +55,7 @@ public class PropertyListParser {
     private static final int TYPE_ERROR_BLANK = 10;
     private static final int TYPE_ERROR_UNKNOWN = 11;
 
-    private static final int READ_BUFFER_LENGTH = 2048;
+    private static final int READ_BUFFER_LENGTH = 4096;
 
     /**
      * Prevent instantiation.
@@ -272,7 +273,7 @@ public class PropertyListParser {
      * @throws IOException If an error occurs during the writing process.
      */
     public static void saveAsXML(NSObject root, OutputStream out) throws IOException {
-        OutputStreamWriter w = new OutputStreamWriter(out, "UTF-8");
+        OutputStreamWriter w = new OutputStreamWriter(out, StandardCharsets.UTF_8);
         w.write(root.toXMLPropertyList());
         w.flush();
     }
@@ -353,7 +354,7 @@ public class PropertyListParser {
             throw new IOException("The output directory does not exist and could not be created.");
         }
 
-        OutputStreamWriter w = new OutputStreamWriter(new FileOutputStream(out), "ASCII");
+        OutputStreamWriter w = new OutputStreamWriter(new FileOutputStream(out), StandardCharsets.US_ASCII);
         try {
             w.write(root.toASCIIPropertyList());
         }
@@ -380,7 +381,7 @@ public class PropertyListParser {
             throw new IOException("The output directory does not exist and could not be created.");
         }
 
-        OutputStreamWriter w = new OutputStreamWriter(new FileOutputStream(out), "ASCII");
+        OutputStreamWriter w = new OutputStreamWriter(new FileOutputStream(out), StandardCharsets.US_ASCII);
         try {
             w.write(root.toASCIIPropertyList());
         }
@@ -433,7 +434,7 @@ public class PropertyListParser {
             throw new IOException("The output directory does not exist and could not be created.");
         }
 
-        OutputStreamWriter w = new OutputStreamWriter(new FileOutputStream(out), "ASCII");
+        OutputStreamWriter w = new OutputStreamWriter(new FileOutputStream(out), StandardCharsets.US_ASCII);
         try {
             w.write(root.toGnuStepASCIIPropertyList());
         }

--- a/src/main/java/com/dd/plist/XMLPropertyListParser.java
+++ b/src/main/java/com/dd/plist/XMLPropertyListParser.java
@@ -22,7 +22,11 @@
  */
 package com.dd.plist;
 
-import org.w3c.dom.*;
+import org.w3c.dom.Document;
+import org.w3c.dom.DocumentType;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+import org.w3c.dom.Text;
 import org.xml.sax.EntityResolver;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
@@ -30,9 +34,15 @@ import org.xml.sax.SAXException;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
-import java.io.*;
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.Reader;
 import java.text.ParseException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Parses XML property lists.
@@ -162,6 +172,24 @@ public class XMLPropertyListParser {
         // Do not pass BOM to XML parser because it can't handle it
         InputStream filteredInputStream = new ByteOrderMarkFilterInputStream(is, false);
         return parse(getDocBuilder().parse(filteredInputStream));
+    }
+    /**
+     * Parses a XML property list from an input stream.
+     * This method does not close the specified input stream.
+     *
+     * @param reader The input reader pointing to the property list's data.
+     * @return The root object of the property list. This is usually a {@link NSDictionary} but can also be a {@link NSArray}.
+     * @see javax.xml.parsers.DocumentBuilder#parse(java.io.InputStream)
+     * @throws javax.xml.parsers.ParserConfigurationException If a document builder for parsing a XML property list
+     *                                                        could not be created. This should not occur.
+     * @throws java.io.IOException If any I/O error occurs while reading the file.
+     * @throws org.xml.sax.SAXException If any parse error occurs.
+     * @throws com.dd.plist.PropertyListFormatException If the given property list has an invalid format.
+     * @throws java.text.ParseException If a date string could not be parsed.
+     */
+    public static NSObject parse(Reader reader)
+            throws ParserConfigurationException, IOException, SAXException, PropertyListFormatException, ParseException {
+        return parse(getDocBuilder().parse(new InputSource(reader)));
     }
 
     /**


### PR DESCRIPTION
There were no possibility to directly parse an XML or ASCII plist form a String or Reader instance.

Furthermore minor improvements to PropertyListParser were made (e.g. reading a file should not use block size lower than 4K as this is inefficient, 4K is the default block size of most file systems).

Using the constants form `StandardCharsets` instead of custom Strings saves the charset name parsing.