### PR TITLE
Minor code style fixes

### DIFF
--- a/src/main/java/com/dd/plist/ASCIIPropertyListParser.java
+++ b/src/main/java/com/dd/plist/ASCIIPropertyListParser.java
@@ -568,7 +568,7 @@ public final class ASCIIPropertyListParser {
 
         //parse end token
         this.read(ARRAY_END_TOKEN);
-        return new NSArray(objects.toArray(new NSObject[objects.size()]));
+        return new NSArray(objects.toArray(new NSObject[0]));
     }
 
     /**

--- a/src/main/java/com/dd/plist/Base64.java
+++ b/src/main/java/com/dd/plist/Base64.java
@@ -29,34 +29,34 @@ import java.nio.charset.StandardCharsets;
 /**
  * <p>Encodes and decodes to and from Base64 notation.</p>
  * <p>Homepage: <a href="http://iharder.net/base64">http://iharder.net/base64</a>.</p>
- * 
+ *
  * <p>Example:</p>
  *
  * <code>String encoded = Base64.encode( myByteArray );</code>
  *
  * <code>byte[] myByteArray = Base64.decode( encoded );</code>
- * 
+ *
  * <p>The <code>options</code> parameter, which appears in a few places, is used to pass
  * several pieces of information to the encoder. In the "higher level" methods such as
  * encodeBytes( bytes, options ) the options parameter can be used to indicate such
  * things as first gzipping the bytes before encoding them, not inserting linefeeds,
  * and encoding using the URL-safe and Ordered dialects.</p>
- * 
+ *
  * <p>Note, according to <a href="http://www.faqs.org/rfcs/rfc3548.html">RFC3548</a>,
  * Section 2.1, implementations should not add line feeds unless explicitly told
  * to do so. I've got Base64 set to this behavior now, although earlier versions
  * broke lines by default.</p>
- * 
+ *
  * <p>The constants defined in Base64 can be OR-ed together to combine options, so you
  * might make a call like this:</p>
- * 
+ *
  * <code>String encoded = Base64.encodeBytes( mybytes, Base64.GZIP | Base64.DO_BREAK_LINES );</code>
  * <p>to compress the data before encoding it and then making the output have newline characters.</p>
  * <p>Also...</p>
  * <code>String encoded = Base64.encodeBytes( crazyString.getBytes() );</code>
- * 
- * 
- * 
+ *
+ *
+ *
  * <p>
  * Change Log:
  * </p>
@@ -133,7 +133,7 @@ import java.nio.charset.StandardCharsets;
  * Special thanks to Jim Kellerman at <a href="http://www.powerset.com/">http://www.powerset.com/</a>
  * for contributing the new Base64 dialects.
  * </li>
- * 
+ *
  * <li>v2.1 - Cleaned up javadoc comments and unused variables and methods. Added
  * some convenience methods for reading and writing to and from files.</li>
  * <li>v2.0.2 - Now specifies UTF-8 encoding in places where the code fails on systems
@@ -641,13 +641,13 @@ public class Base64 {
     /**
      * Serializes an object and returns the Base64-encoded
      * version of that serialized object.
-     * 
+     *
      * <p>As of v 2.3, if the object
      * cannot be serialized or there is another error,
      * the method will throw an java.io.IOException. <b>This is new to v2.3!</b>
      * In earlier versions, it just returned a null value, but
      * in retrospect that's a pretty poor way to handle it.</p>
-     * 
+     *
      * The object is not GZip-compressed before being encoded.
      *
      * @param serializableObject The object to encode
@@ -665,22 +665,22 @@ public class Base64 {
     /**
      * Serializes an object and returns the Base64-encoded
      * version of that serialized object.
-     * 
+     *
      * <p>As of v 2.3, if the object
      * cannot be serialized or there is another error,
      * the method will throw an java.io.IOException. <b>This is new to v2.3!</b>
      * In earlier versions, it just returned a null value, but
      * in retrospect that's a pretty poor way to handle it.</p>
-     * 
+     *
      * The object is not GZip-compressed before being encoded.
-     * 
+     *
      * Example options:<pre>
      *   GZIP: gzip-compresses object before encoding it.
      *   DO_BREAK_LINES: break lines at 76 characters
      * </pre>
-     * 
+     *
      * Example: <code>encodeObject( myObj, Base64.GZIP )</code> or
-     * 
+     *
      * Example: <code>encodeObject( myObj, Base64.GZIP | Base64.DO_BREAK_LINES )</code>
      *
      * @param serializableObject The object to encode
@@ -791,8 +791,8 @@ public class Base64 {
      * Example: <code>encodeBytes( myData, Base64.GZIP )</code> or
      * <p>
      * Example: <code>encodeBytes( myData, Base64.GZIP | Base64.DO_BREAK_LINES )</code>
-     * 
-     * 
+     *
+     *
      * <p>As of v 2.3, if there is an error with the GZIP stream,
      * the method will throw an java.io.IOException. <b>This is new to v2.3!</b>
      * In earlier versions, it just returned a null value, but
@@ -815,7 +815,7 @@ public class Base64 {
     /**
      * Encodes a byte array into Base64 notation.
      * Does not GZip-compress data.
-     * 
+     *
      * <p>As of v 2.3, if there is an error,
      * the method will throw an java.io.IOException. <b>This is new to v2.3!</b>
      * In earlier versions, it just returned a null value, but
@@ -856,8 +856,8 @@ public class Base64 {
      * Example: <code>encodeBytes( myData, Base64.GZIP )</code> or
      * <p>
      * Example: <code>encodeBytes( myData, Base64.GZIP | Base64.DO_BREAK_LINES )</code>
-     * 
-     * 
+     *
+     *
      * <p>As of v 2.3, if there is an error with the GZIP stream,
      * the method will throw an java.io.IOException. <b>This is new to v2.3!</b>
      * In earlier versions, it just returned a null value, but
@@ -1444,7 +1444,7 @@ public class Base64 {
 
     /**
      * Convenience method for encoding data to a file.
-     * 
+     *
      * <p>As of v 2.3, if there is a error,
      * the method will throw an java.io.IOException. <b>This is new to v2.3!</b>
      * In earlier versions, it just returned false, but
@@ -1484,7 +1484,7 @@ public class Base64 {
 
     /**
      * Convenience method for decoding data to a file.
-     * 
+     *
      * <p>As of v 2.3, if there is a error,
      * the method will throw an java.io.IOException. <b>This is new to v2.3!</b>
      * In earlier versions, it just returned false, but
@@ -1520,7 +1520,7 @@ public class Base64 {
     /**
      * Convenience method for reading a base64-encoded
      * file and decoding it.
-     * 
+     *
      * <p>As of v 2.3, if there is a error,
      * the method will throw an java.io.IOException. <b>This is new to v2.3!</b>
      * In earlier versions, it just returned false, but
@@ -1581,7 +1581,7 @@ public class Base64 {
     /**
      * Convenience method for reading a binary file
      * and base64-encoding it.
-     * 
+     *
      * <p>As of v 2.3, if there is a error,
      * the method will throw an java.io.IOException. <b>This is new to v2.3!</b>
      * In earlier versions, it just returned false, but
@@ -1704,15 +1704,15 @@ public class Base64 {
      */
     public static class B64InputStream extends java.io.FilterInputStream {
 
-        private boolean encode;         // Encoding or decoding
+        private final boolean encode;         // Encoding or decoding
         private int position;       // Current position in the buffer
-        private byte[] buffer;         // Small buffer holding converted data
-        private int bufferLength;   // Length of buffer (3 or 4)
+        private final byte[] buffer;         // Small buffer holding converted data
+        private final int bufferLength;   // Length of buffer (3 or 4)
         private int numSigBytes;    // Number of meaningful bytes in the buffer
         private int lineLength;
-        private boolean breakLines;     // Break lines at less than 80 characters
-        private int options;        // Record options used to create the stream.
-        private byte[] decodabet;      // Local copies to avoid extra method calls
+        private final boolean breakLines;     // Break lines at less than 80 characters
+        private final int options;        // Record options used to create the stream.
+        private final byte[] decodabet;      // Local copies to avoid extra method calls
 
 
         /**
@@ -1729,13 +1729,13 @@ public class Base64 {
         /**
          * Constructs a {@link com.dd.plist.Base64.B64InputStream} in
          * either ENCODE or DECODE mode.
-         * 
+         *
          * Valid options:<pre>
          *   ENCODE or DECODE: Encode or Decode as data is read.
          *   DO_BREAK_LINES: break lines at 76 characters
          *     (only meaningful when encoding)
          * </pre>
-         * 
+         *
          * Example: <code>new Base64.B64InputStream( in, Base64.DECODE )</code>
          *
          * @param in      the <code>java.io.InputStream</code> from which to read data.
@@ -1940,13 +1940,13 @@ public class Base64 {
         /**
          * Constructs a {@link com.dd.plist.Base64.B64OutputStream} in
          * either ENCODE or DECODE mode.
-         * 
+         *
          * Valid options:<pre>
          *   ENCODE or DECODE: Encode or Decode as data is read.
          *   DO_BREAK_LINES: don't break lines at 76 characters
          *     (only meaningful when encoding)
          * </pre>
-         * 
+         *
          * Example: <code>new Base64.B64OutputStream( out, Base64.ENCODE )</code>
          *
          * @param out     the <code>java.io.B64OutputStream</code> to which data will be written.

--- a/src/main/java/com/dd/plist/BinaryPropertyListParser.java
+++ b/src/main/java/com/dd/plist/BinaryPropertyListParser.java
@@ -84,7 +84,7 @@ public final class BinaryPropertyListParser {
     private int offsetSize;
     private int numObjects;
     private int offsetTableOffset;
-    private HashMap<Integer, NSObject> parsedObjects = new HashMap<>();
+    private final HashMap<Integer, NSObject> parsedObjects = new HashMap<>();
 
     /**
      * Protected constructor so that instantiation is fully controlled by the

--- a/src/main/java/com/dd/plist/NSNull.java
+++ b/src/main/java/com/dd/plist/NSNull.java
@@ -41,7 +41,7 @@ public final class NSNull extends NSObject {
      * @param o The object.
      * @return The non-null object, or a NSNull instance.
      */
-    protected static NSObject wrap(NSObject o) {
+    static NSObject wrap(NSObject o) {
         return o == null ? NULL : o;
     }
 
@@ -50,7 +50,7 @@ public final class NSNull extends NSObject {
      * @param o The object.
      * @return The non-null object, or null.
      */
-    protected static NSObject unwrap(NSObject o) {
+    static NSObject unwrap(NSObject o) {
         return o == NULL ? null : o;
     }
 

--- a/src/main/java/com/dd/plist/NSObject.java
+++ b/src/main/java/com/dd/plist/NSObject.java
@@ -22,8 +22,6 @@
  */
 package com.dd.plist;
 
-import sun.reflect.generics.reflectiveObjects.NotImplementedException;
-
 import java.io.IOException;
 import java.lang.reflect.*;
 import java.util.*;
@@ -223,8 +221,8 @@ public abstract class NSObject implements Cloneable, Comparable<NSObject> {
 
     private static Object getInstance(Class<?> clazz) {
         try {
-            return clazz.newInstance();
-        } catch (InstantiationException | IllegalAccessException e) {
+            return clazz.getDeclaredConstructor().newInstance();
+        } catch (InstantiationException | IllegalAccessException | NoSuchMethodException | InvocationTargetException e) {
             throw new IllegalArgumentException("Could not instantiate class " + clazz.getSimpleName());
         }
     }
@@ -691,7 +689,7 @@ public abstract class NSObject implements Cloneable, Comparable<NSObject> {
             payload.add(fromJavaObject(elem));
         }
 
-        return new NSArray(payload.toArray(new NSObject[payload.size()]));
+        return new NSArray(payload.toArray(new NSObject[0]));
     }
 
     private static NSSet fromSet(Set<?> set) {

--- a/src/test/java/com/dd/plist/test/model/TestClass1.java
+++ b/src/test/java/com/dd/plist/test/model/TestClass1.java
@@ -2,6 +2,7 @@ package com.dd.plist.test.model;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 public class TestClass1 {
 
@@ -22,7 +23,7 @@ public class TestClass1 {
 
         TestClass1 testClass = (TestClass1) o;
 
-        return map != null ? map.equals(testClass.map) : testClass.map == null;
+        return Objects.equals(map, testClass.map);
 
     }
 

--- a/src/test/java/com/dd/plist/test/model/TestClass2.java
+++ b/src/test/java/com/dd/plist/test/model/TestClass2.java
@@ -1,6 +1,7 @@
 package com.dd.plist.test.model;
 
 import java.util.Date;
+import java.util.Objects;
 
 public class TestClass2 {
 
@@ -144,14 +145,14 @@ public class TestClass2 {
         if (Float.compare(that.aPrimitiveFloat, aPrimitiveFloat) != 0) return false;
         if (aPrimitiveShort != that.aPrimitiveShort) return false;
         if (aPrimitiveBoolean != that.aPrimitiveBoolean) return false;
-        if (aString != null ? !aString.equals(that.aString) : that.aString != null) return false;
-        if (aInteger != null ? !aInteger.equals(that.aInteger) : that.aInteger != null) return false;
-        if (aLong != null ? !aLong.equals(that.aLong) : that.aLong != null) return false;
-        if (aDouble != null ? !aDouble.equals(that.aDouble) : that.aDouble != null) return false;
-        if (aFloat != null ? !aFloat.equals(that.aFloat) : that.aFloat != null) return false;
-        if (aShort != null ? !aShort.equals(that.aShort) : that.aShort != null) return false;
-        if (aBoolean != null ? !aBoolean.equals(that.aBoolean) : that.aBoolean != null) return false;
-        return aDate != null ? aDate.equals(that.aDate) : that.aDate == null;
+        if (!Objects.equals(aString, that.aString)) return false;
+        if (!Objects.equals(aInteger, that.aInteger)) return false;
+        if (!Objects.equals(aLong, that.aLong)) return false;
+        if (!Objects.equals(aDouble, that.aDouble)) return false;
+        if (!Objects.equals(aFloat, that.aFloat)) return false;
+        if (!Objects.equals(aShort, that.aShort)) return false;
+        if (!Objects.equals(aBoolean, that.aBoolean)) return false;
+        return Objects.equals(aDate, that.aDate);
 
     }
 
@@ -169,7 +170,7 @@ public class TestClass2 {
         result = 31 * result + (int) (aPrimitiveLong ^ (aPrimitiveLong >>> 32));
         temp = Double.doubleToLongBits(aPrimitiveDouble);
         result = 31 * result + (int) (temp ^ (temp >>> 32));
-        result = 31 * result + (aPrimitiveFloat != +0.0f ? Float.floatToIntBits(aPrimitiveFloat) : 0);
+        result = 31 * result + (aPrimitiveFloat != 0.0f ? Float.floatToIntBits(aPrimitiveFloat) : 0);
         result = 31 * result + (int) aPrimitiveShort;
         result = 31 * result + (aBoolean != null ? aBoolean.hashCode() : 0);
         result = 31 * result + (aPrimitiveBoolean ? 1 : 0);


### PR DESCRIPTION
- Remove unused import
- Replace deprecated method `newInstance()`
- Don't initialize `toArray()` with a size
- Remove `protected` in final class
- `Objects::equals` in favor of `::equals`