### PR TITLE
Added support for explicit module info(Java 9 or more) without changing target JDK

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,6 +5,7 @@
         <groupId>org.sonatype.oss</groupId>
         <artifactId>oss-parent</artifactId>
         <version>7</version>
+        <relativePath></relativePath>
     </parent>
     <groupId>com.googlecode.plist</groupId>
     <artifactId>dd-plist</artifactId>
@@ -193,6 +194,27 @@
                     <nexusUrl>https://oss.sonatype.org/</nexusUrl>
                     <autoReleaseAfterClose>true</autoReleaseAfterClose>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.moditect</groupId>
+                <artifactId>moditect-maven-plugin</artifactId>
+                <version>1.1.0</version>
+                <executions>
+                    <execution>
+                        <id>add-module-infos</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>add-module-info</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${project.build.directory}</outputDirectory>
+                            <overwriteExistingFiles>true</overwriteExistingFiles>
+                            <module>
+                                <moduleInfoFile>src/main/moditect/module-info.java</moduleInfoFile>
+                            </module>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/src/main/moditect/module-info.java
+++ b/src/main/moditect/module-info.java
@@ -1,0 +1,5 @@
+module dd.plist {
+    exports com.dd.plist;
+
+    requires java.xml;
+}


### PR DESCRIPTION
I've added an explicit module info with the moditect plugin so users using Java 9 or higher can require this module.
This change doesn't impact Java 8